### PR TITLE
[AFID-268][CR,AS] Update frontend design and formatting for 3 new data items

### DIFF
--- a/app/utils/Currency.scala
+++ b/app/utils/Currency.scala
@@ -18,12 +18,11 @@ package utils
 
 import java.util.Locale
 
-case class Currency(value: BigDecimal, decimalPlaces: Int = 0) {
-
+case class Currency(value: BigDecimal, minDecimalPlaces: Int = 0) {
 
   override def toString: String = {
     val formatter = java.text.NumberFormat.getCurrencyInstance(Locale.UK)
-    formatter.setMinimumFractionDigits(decimalPlaces)
+    formatter.setMinimumFractionDigits(minDecimalPlaces)
     if (value.signum >0) {
       formatter.format(value)
     }else{

--- a/app/utils/Currency.scala
+++ b/app/utils/Currency.scala
@@ -18,12 +18,12 @@ package utils
 
 import java.util.Locale
 
-case class Currency(value: BigDecimal) {
+case class Currency(value: BigDecimal, decimalPlaces: Int = 0) {
 
 
   override def toString: String = {
     val formatter = java.text.NumberFormat.getCurrencyInstance(Locale.UK)
-    formatter.setMinimumFractionDigits(0)
+    formatter.setMinimumFractionDigits(decimalPlaces)
     if (value.signum >0) {
       formatter.format(value)
     }else{

--- a/app/views/taxhistory/employment_summary.scala.html
+++ b/app/views/taxhistory/employment_summary.scala.html
@@ -127,26 +127,52 @@
     }
 
     @if(taxAccount.nonEmpty) {
-        <h2 class="heading-medium">@Messages("employmenthistory.tax-account.header", getName)</h2>
+        <h2 class="heading-medium">@Messages("employmenthistory.tax-account.header")</h2>
+        <p>
+            @Messages("employmenthistory.tax-account.caveat.text")
+        </p>
         <table id="taxAccountTable">
+            <thead>
+                <tr>
+                    <th scope="col" width="50%">@Messages("lbl.details")</th>
+                    <th scope="col" width="25%" class="numeric">@Messages("lbl.sa110box")</th>
+                    <th scope="col" width="25%" class="numeric">@Messages("lbl.amount")</th>
+                </tr>
+            </thead>
             <tbody>
                 <tr>
                     <td>@Messages("employmenthistory.tax-account.underpayment-amount.title",
                         s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")</td>
-                    <td class="numeric">@taxAccount.get.underpaymentAmount</td>
+                    <td class="numeric">@Messages("lbl.sa110box.underpayment-amount")</td>
+                    <td class="numeric">@Currency(taxAccount.get.underpaymentAmount.getOrElse(0))</td>
                 </tr>
 
                 <tr>
-                    <td>@Messages("employmenthistory.tax-account.potential-underpayment.title",
+                    <td style = "border:0">@Messages("employmenthistory.tax-account.potential-underpayment.title",
                         s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}",
                         s"${TaxYear.current.currentYear}/${TaxYear.current.finishYear.toString.drop(2)}")</td>
-                    <td class="numeric">@taxAccount.get.actualPUPCodedInCYPlusOneTaxYear</td>
+                    <td style = "border:0" class="numeric">@Messages("lbl.sa110box.potential-underpayment")</td>
+                    <td style = "border:0" class="numeric">@Currency(taxAccount.get.actualPUPCodedInCYPlusOneTaxYear.getOrElse(0))</td>
+                </tr>
+
+                <tr>
+                    <td colspan="3">
+                        <details role="group">
+                            <summary role="button">
+                                <span class="summary">@Messages("employmenthistory.tax-account.potential-underpayment.summary")</span>
+                            </summary>
+                            <div class="panel-border-narrow panel" id="details-content-0">
+                                <p>@Messages("employmenthistory.tax-account.potential-underpayment.content")</p>
+                            </div>
+                        </details>
+                    </td>
                 </tr>
 
                 <tr>
                     <td>@Messages("employmenthistory.tax-account.outstanding.debt.title",
                         s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")</td>
-                    <td class="numeric">@taxAccount.get.outstandingDebtRestriction</td>
+                    <td class="numeric">@Messages("lbl.sa110box.outstanding.debt")</td>
+                    <td class="numeric">@Currency(taxAccount.get.outstandingDebtRestriction.getOrElse(0))</td>
                 </tr>
             </tbody>
         </table>

--- a/app/views/taxhistory/employment_summary.scala.html
+++ b/app/views/taxhistory/employment_summary.scala.html
@@ -144,7 +144,7 @@
                     <td>@Messages("employmenthistory.tax-account.underpayment-amount.title",
                         s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")</td>
                     <td class="numeric">@Messages("lbl.sa110box.underpayment-amount")</td>
-                    <td class="numeric">@Currency(taxAccount.get.underpaymentAmount.getOrElse(0))</td>
+                    <td class="numeric">@Currency(taxAccount.get.underpaymentAmount.getOrElse(0), 2)</td>
                 </tr>
 
                 <tr>
@@ -152,7 +152,7 @@
                         s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}",
                         s"${TaxYear.current.currentYear}/${TaxYear.current.finishYear.toString.drop(2)}")</td>
                     <td style = "border:0" class="numeric">@Messages("lbl.sa110box.potential-underpayment")</td>
-                    <td style = "border:0" class="numeric">@Currency(taxAccount.get.actualPUPCodedInCYPlusOneTaxYear.getOrElse(0))</td>
+                    <td style = "border:0" class="numeric">@Currency(taxAccount.get.actualPUPCodedInCYPlusOneTaxYear.getOrElse(0), 2)</td>
                 </tr>
 
                 <tr>
@@ -172,7 +172,7 @@
                     <td>@Messages("employmenthistory.tax-account.outstanding.debt.title",
                         s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")</td>
                     <td class="numeric">@Messages("lbl.sa110box.outstanding.debt")</td>
-                    <td class="numeric">@Currency(taxAccount.get.outstandingDebtRestriction.getOrElse(0))</td>
+                    <td class="numeric">@Currency(taxAccount.get.outstandingDebtRestriction.getOrElse(0), 2)</td>
                 </tr>
             </tbody>
         </table>

--- a/app/views/taxhistory/employment_summary.scala.html
+++ b/app/views/taxhistory/employment_summary.scala.html
@@ -131,20 +131,21 @@
         <table id="taxAccountTable">
             <tbody>
                 <tr>
-                    <td>@Messages("employmenthistory.tax-account.potential-underpayment.title",
-                    TaxYear.current.currentYear, TaxYear.current.next.currentYear)</td>
-                    <td class="numeric">@taxAccount.get.actualPUPCodedInCYPlusOneTaxYear</td>
-                </tr>
-
-                <tr>
                     <td>@Messages("employmenthistory.tax-account.underpayment-amount.title",
-                        TaxYear.current.previous.currentYear, TaxYear.current.currentYear)</td>
+                        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")</td>
                     <td class="numeric">@taxAccount.get.underpaymentAmount</td>
                 </tr>
 
                 <tr>
+                    <td>@Messages("employmenthistory.tax-account.potential-underpayment.title",
+                        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}",
+                        s"${TaxYear.current.currentYear}/${TaxYear.current.finishYear.toString.drop(2)}")</td>
+                    <td class="numeric">@taxAccount.get.actualPUPCodedInCYPlusOneTaxYear</td>
+                </tr>
+
+                <tr>
                     <td>@Messages("employmenthistory.tax-account.outstanding.debt.title",
-                        TaxYear.current.previous.currentYear, TaxYear.current.currentYear)</td>
+                        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")</td>
                     <td class="numeric">@taxAccount.get.outstandingDebtRestriction</td>
                 </tr>
             </tbody>

--- a/conf/messages
+++ b/conf/messages
@@ -22,7 +22,11 @@ lbl.continue = Continue
 lbl.back = Back
 lbl.employer = Employer
 lbl.provider = Provider
-
+lbl.details = Details
+lbl.sa110box = SA110 box
+lbl.sa110box.underpayment-amount = 7
+lbl.sa110box.potential-underpayment = 8
+lbl.sa110box.outstanding.debt = 9
 
 
 ################################## Client Income Record / Employment Summary ##############################################
@@ -125,13 +129,16 @@ employmenthistory.select.tax.year.error.linktext = Select a tax year
 employmenthistory.select.tax.year.error.message = Select a tax year
 
 ################################## Tax Account ####################################################
-employmenthistory.tax-account.header=Figures related to {0}’s tax codes
+employmenthistory.tax-account.header=Underpaid tax and other debts
+employmenthistory.tax-account.caveat.text=You might need this data if you fill in a Self-Assessment return for your client, SA110 boxes 7, 8 and 9
 #CY
 employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for {0} included in your clients tax code for {1}
+employmenthistory.tax-account.potential-underpayment.summary = Why does this differ from the amount on the P2 Coding Notice?
+employmenthistory.tax-account.potential-underpayment.content = This data reflects the up to date information for your client.
 #CY-1
 employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in your clients tax code for {0}
 #CY-1
-employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your tax code for {0}
+employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your clients tax code for {0}
 
 ################################ Error Pages ###########################################################
 

--- a/conf/messages
+++ b/conf/messages
@@ -127,9 +127,9 @@ employmenthistory.select.tax.year.error.message = Select a tax year
 ################################## Tax Account ####################################################
 employmenthistory.tax-account.header=Figures related to {0}’s tax codes
 #CY
-employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for 6 April 2016 to 5 April 2017 included in your tax code for 6 April {0} to 5 April {0}
+employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for {0} included in your clients tax code for {0}
 #CY-1
-employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in your tax code for 6 April {0} to 5 April {0}
+employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in your clients tax code for {0}
 #CY-1
 employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your tax code for 6 April {0} to 5 April {0}
 

--- a/conf/messages
+++ b/conf/messages
@@ -127,11 +127,11 @@ employmenthistory.select.tax.year.error.message = Select a tax year
 ################################## Tax Account ####################################################
 employmenthistory.tax-account.header=Figures related to {0}’s tax codes
 #CY
-employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for {0} included in your clients tax code for {0}
+employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for {0} included in your clients tax code for {1}
 #CY-1
 employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in your clients tax code for {0}
 #CY-1
-employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your tax code for 6 April {0} to 5 April {0}
+employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your tax code for {0}
 
 ################################ Error Pages ###########################################################
 

--- a/test/utils/CurrencySpec.scala
+++ b/test/utils/CurrencySpec.scala
@@ -29,14 +29,23 @@ class CurrencySpec extends PlaySpec {
       Currency(BigDecimal(-100.55)).toString must be("- £100.55")
     }
 
-    "format number to skip .00 from decimals" in {
+    "format number to skip .00 from decimals when no minDPs is provided" in {
       Currency(BigDecimal(100.00)).toString must be("£100")
     }
-    "format number .12 from decimals" in {
+
+    "format number to convert 100.00 to 100.000 when minDPs is 3" in {
+      Currency(BigDecimal(100.00), 3).toString must be("£100.000")
+    }
+
+    "format number to convert 100 to 100.00 when minDPs is 2" in {
+      Currency(BigDecimal(100), 2).toString must be("£100.00")
+    }
+
+    "format number 100.12 from decimals" in {
       Currency(BigDecimal(100.12)).toString must be("£100.12")
     }
 
-    "format -ve number to skip .00 from decimals" in {
+    "format -ve number to skip .00 from decimals when no minDPs is provided" in {
       Currency(BigDecimal(-100.00)).toString must be("- £100")
     }
   }

--- a/test/views/taxhistory/employment_summarySpec.scala
+++ b/test/views/taxhistory/employment_summarySpec.scala
@@ -86,7 +86,7 @@ class employment_summarySpec extends GuiceAppSpec with Constants {
       caveatParagraphs.contains(Messages("employmenthistory.caveat.p3.text")) mustBe true
     }
 
-    "have correct tax account content when a populated TaxAcxcount is provided" in new ViewFixture {
+    "have correct tax account content when a populated TaxAccount is provided" in new ViewFixture {
       val view = views.html.taxhistory.employment_summary(nino, taxYear, employments, allowances, None, taxAccount)
 
       doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.underpayment-amount.title",

--- a/test/views/taxhistory/employment_summarySpec.scala
+++ b/test/views/taxhistory/employment_summarySpec.scala
@@ -20,6 +20,7 @@ import model.api.EmploymentStatus
 import models.taxhistory.Person
 import play.api.i18n.Messages
 import support.GuiceAppSpec
+import uk.gov.hmrc.time.TaxYear
 import utils.{DateHelper, TestUtil}
 import views.Fixture
 
@@ -45,13 +46,13 @@ class employment_summarySpec extends GuiceAppSpec with Constants {
         (taxYear + 1).toString))
 
       val viewDetailsElements = doc.getElementById("view-employment-0")
-      viewDetailsElements.html must include(Messages("employmenthistory.view.record")+" <span class=\"visuallyhidden\">"+Messages("employmenthistory.view.record.hidden",nino,"employer-2")+"</span>")
+      viewDetailsElements.html must include(Messages("employmenthistory.view.record") + " <span class=\"visuallyhidden\">" + Messages("employmenthistory.view.record.hidden", nino, "employer-2") + "</span>")
       viewDetailsElements.attr("href") mustBe "/tax-history/single-record"
 
 
       val viewPensionElements = doc.getElementById("view-pension-0")
       viewPensionElements.attr("href") mustBe "/tax-history/single-record"
-      viewPensionElements.html must include(Messages("employmenthistory.view.record")+" <span class=\"visuallyhidden\">"+Messages("employmenthistory.view.record.hidden",nino,"employer-1")+"</span>")
+      viewPensionElements.html must include(Messages("employmenthistory.view.record") + " <span class=\"visuallyhidden\">" + Messages("employmenthistory.view.record.hidden", nino, "employer-1") + "</span>")
 
       doc.select("script").toString contains
         "ga('send', 'pageview', { 'anonymizeIp': true })" mustBe true
@@ -83,6 +84,25 @@ class employment_summarySpec extends GuiceAppSpec with Constants {
       caveatParagraphs.contains(Messages("employmenthistory.caveat.p1.text")) mustBe true
       caveatParagraphs.contains(Messages("employmenthistory.caveat.p2.text")) mustBe true
       caveatParagraphs.contains(Messages("employmenthistory.caveat.p3.text")) mustBe true
+    }
+
+    "have correct tax account content when a populated TaxAcxcount is provided" in new ViewFixture {
+      val view = views.html.taxhistory.employment_summary(nino, taxYear, employments, allowances, None, taxAccount)
+
+      doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.underpayment-amount.title",
+        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")).hasText mustBe true
+      doc.getElementsContainingOwnText(oDR).hasText mustBe true
+
+      doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.potential-underpayment.title",
+        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}",
+        s"${TaxYear.current.currentYear}/${TaxYear.current.finishYear.toString.drop(2)}")).hasText mustBe true
+      doc.getElementsContainingOwnText(uA.toString).hasText mustBe true
+
+      doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.outstanding.debt.title",
+        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")).hasText mustBe true
+      doc.getElementsContainingOwnText(aPC.toString).hasText mustBe true
+
+      doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.potential-underpayment.summary")).hasText mustBe true
 
       doc.getElementById("back-link").attr("href") mustBe "/tax-history/select-tax-year"
     }

--- a/test/views/taxhistory/testDataConstants.scala
+++ b/test/views/taxhistory/testDataConstants.scala
@@ -17,6 +17,7 @@
 package views.taxhistory
 
 import java.util.UUID
+import javafx.util.converter.BigDecimalStringConverter
 
 import model.api._
 import org.joda.time.LocalDate
@@ -72,6 +73,11 @@ trait Constants {
     amount = BigDecimal(32.00))
 
   val allowances = List(allowance1, allowance2, allowance3)
+
+  val oDR = "101.01"
+  val uA = "202.00"
+  val aPC = "301.01"
+  val taxAccount = Some(TaxAccount(UUID.randomUUID(), Some(BigDecimal(oDR)), Some(BigDecimal(uA)), Some(BigDecimal(aPC))))
 }
 
 

--- a/test/views/taxhistory/testDataConstants.scala
+++ b/test/views/taxhistory/testDataConstants.scala
@@ -17,7 +17,6 @@
 package views.taxhistory
 
 import java.util.UUID
-import javafx.util.converter.BigDecimalStringConverter
 
 import model.api._
 import org.joda.time.LocalDate


### PR DESCRIPTION
AFID 268:

Changed formatting of the tax history section of the employment summary to match the latest document.

Forced all tax history values to display with 2 decimal places.