### PR TITLE
[AFID-274][CR] Fix back link on enter nino page

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -30,7 +30,6 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
   override lazy val analyticsHost = loadConfig(s"google-analytics.host")
   val AgentAccountHomePage: String = getString("external-url.agent-account-home-page.url")
   val AfiNoAgentServicesAccountPage: String = getString("external-url.afi-not-an-agent-page.url")
-  val AfiErrorPage: String = getString("external-url.afi-error.url")
 
   override lazy val reportAProblemPartialUrl = getString("reportAProblemPartialUrl")
   override lazy val reportAProblemNonJSUrl = getString("reportAProblemNonJSUrl")

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -28,7 +28,7 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
 
   override lazy val analyticsToken = loadConfig(s"google-analytics.token")
   override lazy val analyticsHost = loadConfig(s"google-analytics.host")
-  val AfiHomePage: String = getString("external-url.afi-home-page.url")
+  val AgentAccountHomePage: String = getString("external-url.agent-account-home-page.url")
   val AfiNoAgentServicesAccountPage: String = getString("external-url.afi-not-an-agent-page.url")
   val AfiErrorPage: String = getString("external-url.afi-error.url")
 

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -29,7 +29,6 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
   override lazy val analyticsToken = loadConfig(s"google-analytics.token")
   override lazy val analyticsHost = loadConfig(s"google-analytics.host")
   val AgentAccountHomePage: String = getString("external-url.agent-account-home-page.url")
-  val AfiNoAgentServicesAccountPage: String = getString("external-url.afi-not-an-agent-page.url")
 
   override lazy val reportAProblemPartialUrl = getString("reportAProblemPartialUrl")
   override lazy val reportAProblemNonJSUrl = getString("reportAProblemNonJSUrl")

--- a/app/controllers/auth/AgentAuth.scala
+++ b/app/controllers/auth/AgentAuth.scala
@@ -16,8 +16,6 @@
 
 package controllers.auth
 
-import config.FrontendAppConfig.AfiNoAgentServicesAccountPage
-import play.api.Logger
 import play.api.mvc.{AnyContent, Request, Result}
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
 import uk.gov.hmrc.auth.core.ConfidenceLevel.L200
@@ -30,9 +28,9 @@ import scala.concurrent.Future
 
 trait AgentAuth extends FrontendController with AuthorisedFunctions with AuthRedirects {
 
-  def redirectToSubPage: Future[Result] = Future successful Redirect(AfiNoAgentServicesAccountPage)
+  def redirectToSubPage: Future[Result] = Future successful Redirect(controllers.routes.ClientErrorController.getNotAuthorised())
 
-  def redirectToExitPage: Future[Result] = Future successful Redirect(AfiNoAgentServicesAccountPage)
+  def redirectToExitPage: Future[Result] = Future successful Redirect(controllers.routes.ClientErrorController.getNotAuthorised())
 
   def isAgent(group: AffinityGroup): Boolean = group.toString.contains("Agent")
 

--- a/app/controllers/auth/AgentAuth.scala
+++ b/app/controllers/auth/AgentAuth.scala
@@ -16,7 +16,7 @@
 
 package controllers.auth
 
-import config.FrontendAppConfig.{AfiErrorPage, AgentAccountHomePage, AfiNoAgentServicesAccountPage}
+import config.FrontendAppConfig.AfiNoAgentServicesAccountPage
 import play.api.Logger
 import play.api.mvc.{AnyContent, Request, Result}
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
@@ -50,13 +50,4 @@ trait AgentAuth extends FrontendController with AuthorisedFunctions with AuthRed
   val isAuthorisedForPAYE = true
   val isNotAuthorisedForPAYE = false
 
-  def handleFailure(e: Throwable): Result =
-    e match {
-      case x: NoActiveSession ⇒
-        Logger.warn(s"could not authenticate user due to: No Active Session " + x)
-        toGGLogin(AgentAccountHomePage)
-      case ex ⇒
-        Logger.warn(s"could not authenticate user due to: $ex")
-        Redirect(AfiErrorPage)
-    }
 }

--- a/app/controllers/auth/AgentAuth.scala
+++ b/app/controllers/auth/AgentAuth.scala
@@ -16,7 +16,7 @@
 
 package controllers.auth
 
-import config.FrontendAppConfig.{AfiErrorPage, AfiHomePage, AfiNoAgentServicesAccountPage}
+import config.FrontendAppConfig.{AfiErrorPage, AgentAccountHomePage, AfiNoAgentServicesAccountPage}
 import play.api.Logger
 import play.api.mvc.{AnyContent, Request, Result}
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
@@ -54,7 +54,7 @@ trait AgentAuth extends FrontendController with AuthorisedFunctions with AuthRed
     e match {
       case x: NoActiveSession ⇒
         Logger.warn(s"could not authenticate user due to: No Active Session " + x)
-        toGGLogin(AfiHomePage)
+        toGGLogin(AgentAccountHomePage)
       case ex ⇒
         Logger.warn(s"could not authenticate user due to: $ex")
         Redirect(AfiErrorPage)

--- a/app/views/errors/technical_error.scala.html
+++ b/app/views/errors/technical_error.scala.html
@@ -19,7 +19,7 @@
 @()(implicit request: Request[_], messages: Messages)
 
 @mainContent = {
-  <a href="@FrontendAppConfig.AfiHomePage" class="link-back" id="back-link">@Messages("lbl.back")</a>
+  <a href="@FrontendAppConfig.AgentAccountHomePage" class="link-back" id="back-link">@Messages("lbl.back")</a>
 
   <h1 class="heading-xlarge" id="error-heading">@Messages("employmenthistory.technical.error.header")</h1>
   <p> @Messages("employmenthistory.technical.error.message") </p>

--- a/app/views/taxhistory/select_client.scala.html
+++ b/app/views/taxhistory/select_client.scala.html
@@ -26,7 +26,7 @@
                           bodyClasses = None,
                           sidebarLinks = None) {
 
-    <a href="@FrontendAppConfig.AfiHomePage" class="link-back" id="back-link">@Messages("lbl.back")</a>
+    <a href="@FrontendAppConfig.AgentAccountHomePage" class="link-back" id="back-link">@Messages("lbl.back")</a>
 
     <section class="section" >
         @helpers.form(routes.SelectClientController.submitSelectClientPage()){

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -85,9 +85,6 @@ external-url {
   agent-account-home-page{
     url = "http://localhost:9401/agent-services-account"
   }
-  afi-not-an-agent-page {
-    url = "http://localhost:9428/agent-services/individuals/no-agent-services-account"
-  }
 }
 
 metrics {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -82,8 +82,8 @@ external-url {
   government-gateway {
     host = "http://localhost:9025"
   }
-  afi-home-page{
-    url = "http://localhost:9428/agent-services/individuals"
+  agent-account-home-page{
+    url = "http://localhost:9401/agent-services-account"
   }
   afi-not-an-agent-page {
     url = "http://localhost:9428/agent-services/individuals/no-agent-services-account"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -88,9 +88,6 @@ external-url {
   afi-not-an-agent-page {
     url = "http://localhost:9428/agent-services/individuals/no-agent-services-account"
   }
-  afi-error {
-    url = "http://localhost:9428/agent-services/individuals/error"
-  }
 }
 
 metrics {

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -18,48 +18,31 @@ package controllers
 
 import javax.inject.Inject
 
-import config.FrontendAppConfig.getString
 import config.{FrontendAppConfig, FrontendAuthConnector}
 import models.taxhistory.Person
 import org.mockito.Matchers
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
+import play.api.{Configuration, Environment}
 import play.api.http.Status
 import play.api.i18n.MessagesApi
-import play.api.libs.json.Json
 import play.api.mvc.Results
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.api.{Configuration, Environment}
-import support.GuiceAppSpec
+import support.ControllerSpec
 import support.fixtures.{Fixtures, PersonFixture}
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{BadGatewayException, HttpResponse, SessionKeys}
-import utils.TestUtil
+import uk.gov.hmrc.http.{BadGatewayException, HttpResponse}
+import uk.gov.hmrc.play.frontend.auth.connectors.domain.Authority
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class BaseControllerSpec extends GuiceAppSpec with Fixtures with TestUtil {
+class BaseControllerSpec extends ControllerSpec with Fixtures {
 
-  lazy val nino = randomNino.toString()
-
-  lazy val fakeRequest = FakeRequest("GET", "/").withSession(
-    SessionKeys.sessionId -> "SessionId",
-    SessionKeys.token -> "Token",
-    SessionKeys.userId -> "/auth/oid/tuser",
-    SessionKeys.authToken -> ""
-  )
-
-  lazy val newEnrolments = Set(
-    Enrolment("HMRC-AS-AGENT", Seq(EnrolmentIdentifier("AgentReferenceNumber", "TestArn")),
-      confidenceLevel = ConfidenceLevel.L200,
-      state="",delegatedAuthRule = None)
-  )
-
-  lazy val authority = buildFakeAuthority(true)
+  lazy val authority: Authority = buildFakeAuthority(true)
 
   trait HappyPathSetup {
 
@@ -70,7 +53,6 @@ class BaseControllerSpec extends GuiceAppSpec with Fixtures with TestUtil {
       c
     }
   }
-
 
   trait NoEnrolmentsSetup {
 
@@ -256,9 +238,8 @@ class BaseControllerSpec extends GuiceAppSpec with Fixtures with TestUtil {
   }
 }
 
-class Controller  @Inject()(
-                             override val authConnector: FrontendAuthConnector,
-                             override val config: Configuration,
-                             override val env: Environment,
-                             implicit val messagesApi: MessagesApi
-                           ) extends BaseController
+class Controller @Inject()(override val authConnector: FrontendAuthConnector,
+                           override val config: Configuration,
+                           override val env: Environment,
+                           implicit val messagesApi: MessagesApi
+                          ) extends BaseController

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -134,25 +134,25 @@ class BaseControllerSpec extends GuiceAppSpec with Fixtures with TestUtil {
 
   "BaseController" must {
 
-    "redirect to afi-not-an-agent-page when there is no enrolment" in new NoEnrolmentsSetup {
+    "redirect to not authorised when there is no enrolment" in new NoEnrolmentsSetup {
       val result = controller.authorisedForAgent(_ =>Future.successful(Results.Ok("test")))(hc,
         fakeRequest.withSession("USER_NINO" -> nino))
       status(result) shouldBe Status.SEE_OTHER
-      redirectLocation(result) shouldBe Some(getString("external-url.afi-not-an-agent-page.url"))
+      redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getNotAuthorised().url)
     }
 
-    "redirect to afi-not-an-agent-page when there is no enrolment and is not an agent" in new NoEnrolmentsAndNotAnAgentSetup {
+    "redirect to not authorised when there is no enrolment and is not an agent" in new NoEnrolmentsAndNotAnAgentSetup {
       val result = controller.authorisedForAgent(_ => Future.successful(Results.Ok("test")))(hc,
         fakeRequest.withSession("USER_NINO" -> nino))
       status(result) shouldBe Status.SEE_OTHER
-      redirectLocation(result) shouldBe Some(getString("external-url.afi-not-an-agent-page.url"))
+      redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getNotAuthorised().url)
     }
 
-    "redirect to afi-not-an-agent-page when there is no enrolment and has no affinity group" in new NoEnrolmentsAndNoAffinityGroupSetup {
+    "redirect to not authorised when there is no enrolment and has no affinity group" in new NoEnrolmentsAndNoAffinityGroupSetup {
       val result = controller.authorisedForAgent(_ => Future.successful(Results.Ok("test")))(hc,
         fakeRequest.withSession("USER_NINO" -> nino))
       status(result) shouldBe Status.SEE_OTHER
-      redirectLocation(result) shouldBe Some(getString("external-url.afi-not-an-agent-page.url"))
+      redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getNotAuthorised().url)
     }
 
     "load error page when failed to fetch enrolment" in new failureOnRetrievalOfEnrolment {

--- a/test/controllers/ClientErrorControllerSpec.scala
+++ b/test/controllers/ClientErrorControllerSpec.scala
@@ -23,15 +23,15 @@ import play.api.http.Status
 import play.api.i18n.Messages
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import org.mockito.Matchers
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import play.api.libs.json.Json
+import support.{ControllerSpec, GuiceAppSpec}
 import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.Future
 
-class ClientErrorControllerSpec extends BaseControllerSpec {
+class ClientErrorControllerSpec extends ControllerSpec {
 
   trait HappyPathSetup {
 

--- a/test/controllers/EmploymentDetailControllerSpec.scala
+++ b/test/controllers/EmploymentDetailControllerSpec.scala
@@ -22,7 +22,6 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import support.fixtures.PersonFixture
 import model.api.{CompanyBenefit, Employment, EmploymentStatus, PayAndTax}
-import models.taxhistory.Person
 import org.joda.time.LocalDate
 import org.mockito.Matchers
 import org.mockito.Matchers.any
@@ -31,19 +30,20 @@ import play.api.http.Status
 import play.api.i18n.Messages
 import play.api.libs.json.Json
 import play.api.test.Helpers._
+import support.ControllerSpec
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
 import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.Future
 
-class EmploymentDetailControllerSpec extends BaseControllerSpec with PersonFixture{
+class EmploymentDetailControllerSpec extends ControllerSpec with PersonFixture{
 
   trait HappyPathSetup {
 
-    implicit val actorSystem = ActorSystem("test")
-    implicit val materializer = ActorMaterializer()
-    lazy val controller = {
+    implicit val actorSystem: ActorSystem = ActorSystem("test")
+    implicit val materializer: ActorMaterializer = ActorMaterializer()
+    lazy val controller: EmploymentDetailController = {
 
       val c = injected[EmploymentDetailController]
       val cbUUID = UUID.randomUUID()

--- a/test/controllers/EmploymentSummaryControllerSpec.scala
+++ b/test/controllers/EmploymentSummaryControllerSpec.scala
@@ -32,6 +32,7 @@ import play.api.i18n.Messages
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import support.ControllerSpec
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.domain.Nino
@@ -39,7 +40,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import scala.concurrent.Future
 
-class EmploymentSummaryControllerSpec extends BaseControllerSpec with PersonFixture{
+class EmploymentSummaryControllerSpec extends ControllerSpec with PersonFixture{
 
   val startDate = new LocalDate("2016-01-21")
 

--- a/test/controllers/SelectClientControllerSpec.scala
+++ b/test/controllers/SelectClientControllerSpec.scala
@@ -23,12 +23,13 @@ import play.api.http.Status
 import play.api.i18n.Messages
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import support.ControllerSpec
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
 
 import scala.concurrent.Future
 
-class SelectClientControllerSpec extends BaseControllerSpec {
+class SelectClientControllerSpec extends ControllerSpec {
 
   trait LocalSetup {
 

--- a/test/controllers/SelectTaxYearControllerSpec.scala
+++ b/test/controllers/SelectTaxYearControllerSpec.scala
@@ -27,13 +27,14 @@ import play.api.i18n.Messages
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import support.ControllerSpec
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
 import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.Future
 
-class SelectTaxYearControllerSpec extends BaseControllerSpec with PersonFixture{
+class SelectTaxYearControllerSpec extends ControllerSpec with PersonFixture{
 
   trait LocalSetup {
 

--- a/test/support/ControllerSpec.scala
+++ b/test/support/ControllerSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package support
+
+import javax.inject.Inject
+
+import config.FrontendAuthConnector
+import controllers.BaseController
+import play.api.{Configuration, Environment}
+import play.api.i18n.MessagesApi
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import uk.gov.hmrc.auth.core.{ConfidenceLevel, Enrolment, EnrolmentIdentifier}
+import uk.gov.hmrc.http.SessionKeys
+import utils.TestUtil
+
+trait ControllerSpec extends GuiceAppSpec with BaseSpec with TestUtil {
+
+  lazy val nino: String = randomNino().toString()
+
+  lazy val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/").withSession(
+    SessionKeys.sessionId -> "SessionId",
+    SessionKeys.token -> "Token",
+    SessionKeys.userId -> "/auth/oid/tuser",
+    SessionKeys.authToken -> ""
+  )
+
+  lazy val newEnrolments = Set(
+    Enrolment("HMRC-AS-AGENT", Seq(EnrolmentIdentifier("AgentReferenceNumber", "TestArn")),
+      confidenceLevel = ConfidenceLevel.L200,
+      state = "", delegatedAuthRule = None)
+  )
+
+  implicit val messagesApi: MessagesApi
+
+}

--- a/test/views/errors/technical_errorSpec.scala
+++ b/test/views/errors/technical_errorSpec.scala
@@ -19,6 +19,7 @@ package views.errors
 import play.api.i18n.Messages
 import support.GuiceAppSpec
 import views.Fixture
+import config.FrontendAppConfig
 
 class technical_errorSpec extends GuiceAppSpec {
 
@@ -34,7 +35,7 @@ class technical_errorSpec extends GuiceAppSpec {
 
       val title = Messages("employmenthistory.technical.error.title")
       doc.title mustBe title
-      doc.getElementById("back-link").attr("href").contains("/agent-services/individuals") mustBe true
+      doc.getElementById("back-link").attr("href").contains(FrontendAppConfig.AgentAccountHomePage) mustBe true
       doc.getElementById("back-link").text mustBe Messages("lbl.back")
       doc.select("h1").text() mustBe Messages("employmenthistory.technical.error.header")
       doc.getElementsMatchingOwnText(Messages("employmenthistory.technical.error.message")).size() mustBe 1


### PR DESCRIPTION
Set the back link on enter nino page to redirect to agent account.
Removed unused config & related unused code.
Redirect to local not authorised page in place of AFI not authorised.
Break the dependency between base controller tests and other controller tests that leads to base controller tests being run repeatedly.