### PR TITLE
[Afid 287] Display Client Name in Screen

### DIFF
--- a/app/controllers/SelectTaxYearController.scala
+++ b/app/controllers/SelectTaxYearController.scala
@@ -54,14 +54,14 @@ class SelectTaxYearController @Inject()(
     }
   }
 
-  private def fetchTaxYearsAndRenderPage(form: Form[SelectTaxYear], httpStatus: Status, nino: Nino)
+  private def fetchTaxYearsAndRenderPage(form: Form[SelectTaxYear], httpStatus: Status, nino: Nino, clientName:Option[String])
                                         (implicit hc: HeaderCarrier, request: Request[_]): Future[Result] = {
     taxHistoryConnector.getTaxYears(nino) map { taxYearResponse =>
       taxYearResponse.status match {
         case OK => {
           val taxYears = getTaxYears(taxYearResponse.json.as[List[IndividualTaxYear]])
 
-          httpStatus(select_tax_year(form, taxYears))
+          httpStatus(select_tax_year(form, taxYears, clientName.getOrElse(nino.value)))
         }
         case status => handleHttpFailureResponse(status, nino)
       }
@@ -72,7 +72,7 @@ class SelectTaxYearController @Inject()(
                                      (implicit hc: HeaderCarrier, request: Request[_]): Future[Result] = {
     retrieveCitizenDetails(nino, citizenDetailsConnector.getPersonDetails(nino)) flatMap {
       case Left(citizenStatus) => redirectToClientErrorPage(citizenStatus)
-      case Right(_) => fetchTaxYearsAndRenderPage(form, httpStatus, nino)
+      case Right(p) => fetchTaxYearsAndRenderPage(form, httpStatus, nino, p.getName)
     }
   }
 

--- a/app/views/taxhistory/employment_summary.scala.html
+++ b/app/views/taxhistory/employment_summary.scala.html
@@ -128,30 +128,24 @@
 
     @if(taxAccount.nonEmpty) {
         <h2 class="heading-medium">@Messages("employmenthistory.tax-account.header")</h2>
-        <p>
-            @Messages("employmenthistory.tax-account.caveat.text")
-        </p>
         <table id="taxAccountTable">
             <thead>
                 <tr>
-                    <th scope="col" width="50%">@Messages("lbl.details")</th>
-                    <th scope="col" width="25%" class="numeric">@Messages("lbl.sa110box")</th>
+                    <th scope="col" width="75%">@Messages("lbl.details")</th>
                     <th scope="col" width="25%" class="numeric">@Messages("lbl.amount")</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td>@Messages("employmenthistory.tax-account.underpayment-amount.title",
-                        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")</td>
-                    <td class="numeric">@Messages("lbl.sa110box.underpayment-amount")</td>
+                        s"${TaxYear.current.previous.currentYear}", s"${TaxYear.current.previous.finishYear}")</td>
                     <td class="numeric">@Currency(taxAccount.get.underpaymentAmount.getOrElse(0), 2)</td>
                 </tr>
 
                 <tr>
                     <td style = "border:0">@Messages("employmenthistory.tax-account.potential-underpayment.title",
-                        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}",
-                        s"${TaxYear.current.currentYear}/${TaxYear.current.finishYear.toString.drop(2)}")</td>
-                    <td style = "border:0" class="numeric">@Messages("lbl.sa110box.potential-underpayment")</td>
+                        s"${TaxYear.current.previous.currentYear}",s"${TaxYear.current.previous.finishYear}",
+                        s"${TaxYear.current.currentYear}",s"${TaxYear.current.finishYear}")</td>
                     <td style = "border:0" class="numeric">@Currency(taxAccount.get.actualPUPCodedInCYPlusOneTaxYear.getOrElse(0), 2)</td>
                 </tr>
 
@@ -170,8 +164,7 @@
 
                 <tr>
                     <td>@Messages("employmenthistory.tax-account.outstanding.debt.title",
-                        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")</td>
-                    <td class="numeric">@Messages("lbl.sa110box.outstanding.debt")</td>
+                        s"${TaxYear.current.previous.currentYear}",s"${TaxYear.current.previous.finishYear}")</td>
                     <td class="numeric">@Currency(taxAccount.get.outstandingDebtRestriction.getOrElse(0), 2)</td>
                 </tr>
             </tbody>

--- a/app/views/taxhistory/select_tax_year.scala.html
+++ b/app/views/taxhistory/select_tax_year.scala.html
@@ -18,7 +18,8 @@
 @import uk.gov.hmrc.play.views.html.helpers
 
 @(form: Form[SelectTaxYear],
-taxYears:List[(String, String)])(implicit request: Request[_], messages: Messages)
+taxYears:List[(String, String)],
+clientName:String)(implicit request: Request[_], messages: Messages)
 
 @views.html.main_template(title = Messages("employmenthistory.select.tax.year.title")){
 
@@ -43,6 +44,7 @@ taxYears:List[(String, String)])(implicit request: Request[_], messages: Message
 
 <div class="page-header" >
     <h1 class="heading-xlarge">
+        <span class="pre-heading">@Messages("employmenthistory.display.client.name",s"${clientName}")</span>
         @Messages("employmenthistory.select.tax.year.h1")
     </h1>
 </div>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -116,7 +116,7 @@ google-analytics {
 }
 
 assets {
-  version = "2.252.0"
+  version = "3.0.2"
   url = "http://localhost:9032/assets/"
   minified = true
 }

--- a/conf/messages
+++ b/conf/messages
@@ -125,15 +125,15 @@ employmenthistory.select.tax.year.error.linktext = Select a tax year
 employmenthistory.select.tax.year.error.message = Select a tax year
 
 ################################## Tax Account ####################################################
-employmenthistory.tax-account.header=Underpaid tax and other debts
+employmenthistory.tax-account.header=Underpaid tax and debts
 #CY
-employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for {0} to {1} included in your clients tax code for {2} to {3}
+employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for tax year {0} to {1} included in your client''s tax code {2} to {3}
 employmenthistory.tax-account.potential-underpayment.summary = Why does this differ from the amount on the P2 Coding Notice?
 employmenthistory.tax-account.potential-underpayment.content = This data reflects the up to date information for your client.
 #CY-1
-employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in your clients tax code for {0} to {1}
+employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in your client''s tax code for tax year {0} to {1}
 #CY-1
-employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your clients tax code for {0} to {1}
+employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your client''s tax code for tax year {0} to {1}
 
 ################################ Error Pages ###########################################################
 

--- a/conf/messages
+++ b/conf/messages
@@ -23,10 +23,6 @@ lbl.back = Back
 lbl.employer = Employer
 lbl.provider = Provider
 lbl.details = Details
-lbl.sa110box = SA110 box
-lbl.sa110box.underpayment-amount = 7
-lbl.sa110box.potential-underpayment = 8
-lbl.sa110box.outstanding.debt = 9
 
 
 ################################## Client Income Record / Employment Summary ##############################################
@@ -130,15 +126,14 @@ employmenthistory.select.tax.year.error.message = Select a tax year
 
 ################################## Tax Account ####################################################
 employmenthistory.tax-account.header=Underpaid tax and other debts
-employmenthistory.tax-account.caveat.text=You might need this data if you fill in a Self-Assessment return for your client, SA110 boxes 7, 8 and 9.
 #CY
-employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for {0} included in your clients tax code for {1}
+employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for {0} to {1} included in your clients tax code for {2} to {3}
 employmenthistory.tax-account.potential-underpayment.summary = Why does this differ from the amount on the P2 Coding Notice?
 employmenthistory.tax-account.potential-underpayment.content = This data reflects the up to date information for your client.
 #CY-1
-employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in your clients tax code for {0}
+employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in your clients tax code for {0} to {1}
 #CY-1
-employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your clients tax code for {0}
+employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in your clients tax code for {0} to {1}
 
 ################################ Error Pages ###########################################################
 

--- a/conf/messages
+++ b/conf/messages
@@ -46,7 +46,7 @@ employmenthistory.caveat.p2.text = You should always check with your client befo
 employmenthistory.caveat.p3.text = We will not provide missing information by phone or provide certain data, such as bankruptcy.
 employmenthistory.select.different.taxyear.link = Select a different tax year
 employmenthistory.select.different.taxyear.link.lower = select a different tax year
-
+employmenthistory.display.client.name = {0}''s income records
 
 ################################## Company Benefits & Allowances ##################################
 

--- a/test/views/taxhistory/employment_summarySpec.scala
+++ b/test/views/taxhistory/employment_summarySpec.scala
@@ -90,16 +90,16 @@ class employment_summarySpec extends GuiceAppSpec with Constants {
       val view = views.html.taxhistory.employment_summary(nino, taxYear, employments, allowances, None, taxAccount)
 
       doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.underpayment-amount.title",
-        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")).hasText mustBe true
+        s"${TaxYear.current.previous.currentYear}",s"${TaxYear.current.previous.finishYear}")).hasText mustBe true
       doc.getElementsContainingOwnText(oDR).hasText mustBe true
 
       doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.potential-underpayment.title",
-        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}",
-        s"${TaxYear.current.currentYear}/${TaxYear.current.finishYear.toString.drop(2)}")).hasText mustBe true
+        s"${TaxYear.current.previous.currentYear}",s"${TaxYear.current.previous.finishYear}",
+        s"${TaxYear.current.currentYear}",s"${TaxYear.current.finishYear}")).hasText mustBe true
       doc.getElementsContainingOwnText(uA.toString).hasText mustBe true
 
       doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.outstanding.debt.title",
-        s"${TaxYear.current.previous.currentYear}/${TaxYear.current.previous.finishYear.toString.drop(2)}")).hasText mustBe true
+        s"${TaxYear.current.previous.currentYear}",s"${TaxYear.current.previous.finishYear}")).hasText mustBe true
       doc.getElementsContainingOwnText(aPC.toString).hasText mustBe true
 
       doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.potential-underpayment.summary")).hasText mustBe true


### PR DESCRIPTION
Added the client's name to the selectTaxYear page.
If no client name is available, the nino will be displayed instead, as elsewhere in the project 