### PR TITLE
DDCE-2156: update logging config

### DIFF
--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -7,6 +7,10 @@
 
     <logger name="uk.gov" level="${logger.uk.gov:-INFO}"/>
 
+    <!--  default application logging level, also substituted below?  -->
+    <logger name="application" level="{logger.application:-INFO}"/>
+
+    <!--  uses the default "application" logger level: http://logback.qos.ch/manual/configuration.html#defaultValuesForVariables  -->
     <logger name="connectors" level="${logger.application:-INFO}"/>
 
     <logger name="controllers" level="${logger.application:-INFO}"/>
@@ -19,7 +23,8 @@
 
     <logger name="play.core.netty" additivity="false" level="WARN"/>
 
-    <root level="${logger.application:-ERROR}">
+    <!--  use the root level from the default logback config? default to INFO -->
+    <root level="${logger.root:-INFO}">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -47,6 +47,8 @@
 
     <logger name="uk.gov" level="INFO"/>
 
+    <logger name="application" level="INFO"/>
+
     <logger name="connector" level="TRACE">
         <appender-ref ref="STDOUT"/>
     </logger>


### PR DESCRIPTION
JSON logger appeared to be configured to only output `ERROR` level: lowered to `INFO`.
"application" logger added as a default for the log levels following. 

Needs to be tested in a deployed environment (no local JSON logs) :confused: 