### PR TITLE
DDCE-2947 - View link visually hidden text issue identified in DAC report

### DIFF
--- a/app/views/taxhistory/employment_summary.scala.html
+++ b/app/views/taxhistory/employment_summary.scala.html
@@ -239,7 +239,7 @@
 
                             <a href="/tax-history/single-record@employment.employmentURI" id=@{s"view-link-employment-${index}"}>
                                 @messages("employmenthistory.view")
-                                <span class="govuk-visually-hidden">@messages("employmenthistory.view.record.hidden",getName,employment.employerName)</span>
+                                <span class="govuk-visually-hidden">@messages("employmenthistory.view.record.hidden",getName, ControllerUtils.isJobSeekerAllowance(employment))</span>
                             </a>
                         } else {
                             <span id=@{s"view-employment-${index}"}>@messages("lbl.none")</span>


### PR DESCRIPTION
# DDCE-2947 - View link visually hidden text issue identified in DAC report

Description: 
“View Hazel Young’s income record for” copy applied on “view” link associated to Jobseeker’s allowance. This might mislead screen reader users and make a mistake.
Resolve: 

If the employment is Jobseeker's Allowance, then the job record should show as Jobseeker's allowance and be updated as per the below:
Update the tag to the following: "View Hazel Young’s income record for Jobseeker’s Allowance"
Acceptance criteria
 - [x]  Ensure we are updating the tag text
 - [x]  Present to the Design Team
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 
<img width="1562" alt="visually hidden tag text updated" src="https://user-images.githubusercontent.com/369407/164040936-8571aac7-5cba-4fa5-8e00-137df1c31831.png">

