### PR TITLE
DDCE-2995 - accessibility statement link

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -157,6 +157,8 @@ featureFlags {
 
 play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:12345 localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com https://www.googletagmanager.com https://www.google-analytics.com https://fonts.googleapis.com https://tagmanager.google.com https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com data:;"
 
+accessibility-statement.service-path = "/income-record-viewer"
+
 tracking-consent-frontend {
   gtm.container = "c"
 }


### PR DESCRIPTION
# DDCE-2995 - accessibility statement link

Adds an accessibility statement link at the bottom of the application.

The content has been reviewed by Victoria Uhiara

<img width="774" alt="Screenshot 2022-04-28 at 15 05 08" src="https://user-images.githubusercontent.com/369407/165771024-6e9912b6-7be5-41b7-9d5d-a2b0ee0fc1d7.png">

