### PR TITLE
DDCE-2960 - IRV Design Changes- Add in Data labels on the Underpaid tax and debts tab

### DIFF
--- a/app/views/taxhistory/employment_summary.scala.html
+++ b/app/views/taxhistory/employment_summary.scala.html
@@ -50,22 +50,18 @@
 
 @govukWrapper(PageTitle(messages("employmenthistory.title")), backLink =  Some(controllers.routes.SelectTaxYearController.getSelectTaxYearPage().url)) {
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <header class="hmrc-page-heading no-top-margin">
-            <h1 class="govuk-heading-xl no-bottom-margin" id="header">@messages("employmenthistory.header")</h1>
-            <p id="pre-header" class="hmrc-caption govuk-caption-l govuk-!-padding-bottom-1">
-                <span class="govuk-visually-hidden">This section relates to </span>
-                @getName
-            </p>
-            <span class="govuk-heading-m" id="taxYearRange">@messages("employmenthistory.taxyear", taxYear.toString, (taxYear+1).toString) </span>
-        </header>
+<header class="hmrc-page-heading no-top-margin">
+    <h1 class="govuk-heading-xl no-bottom-margin" id="header">@messages("employmenthistory.header")</h1>
+    <p id="pre-header" class="hmrc-caption govuk-caption-l govuk-!-padding-bottom-1">
+        <span class="govuk-visually-hidden">This section relates to </span>
+        @getName
+    </p>
+    <span class="govuk-heading-m" id="taxYearRange">@messages("employmenthistory.taxyear", taxYear.toString, (taxYear+1).toString) </span>
+</header>
 
-        <div class="govuk-inset-text govuk-!-margin-bottom-9 no-top-margin">
-            @p(Html(messages("employmenthistory.caveat.p1.text")), id = Some("disclaimer-0"))
-            @p(Html(messages("employmenthistory.caveat.p2.text")), id = Some("disclaimer-1"))
-        </div>
-    </div>
+<div class="govuk-inset-text govuk-!-margin-bottom-9 no-top-margin">
+    @p(Html(messages("employmenthistory.caveat.p1.text")), id = Some("disclaimer-0"))
+    @p(Html(messages("employmenthistory.caveat.p2.text")), id = Some("disclaimer-1"))
 </div>
 
 <div class="govuk-tabs" data-module="govuk-tabs">
@@ -158,15 +154,10 @@
         <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="underpaid-tax-and-debts">
             <h2 id = "UnderpaidTaxAndDebts" class="govuk-heading-m blue-underline">@messages("employmenthistory.tax-account.header")</h2>
             @if(taxAccount.nonEmpty) {
-                <div class = "govuk-grid-row">
-                    <div class = "govuk-grid-column-two-thirds">
-                        @taxAccountTable
-                    </div>
-                    <div class="govuk-grid-column-one-third"></div>
-                </div>
-                } else {
-                    <p id="no-tax-account" class="govuk-body">@messages("employmenthistory.tax-account.empty.text")</p>
-                }
+                @taxAccountTable
+            } else {
+                <p id="no-tax-account" class="govuk-body">@messages("employmenthistory.tax-account.empty.text")</p>
+            }
         </div>
     }
 
@@ -300,31 +291,43 @@
     <table id="taxAccountTable" class="govuk-table">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">@messages("lbl.details")</th>
+            <th scope="col" class="govuk-table__header">@messages("employmenthistory.tax-account.type-of-underpayment-or-debt")</th>
             <th scope="col" class="govuk-table__header govuk-table__header--numeric">@messages("lbl.amount")</th>
         </tr>
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell govuk-body-s">@messages("employmenthistory.tax-account.underpayment-amount.title",
-                    s"${TaxYear.current.previous.currentYear}", s"${TaxYear.current.previous.finishYear}")</td>
-                <td class="govuk-table__cell govuk-body-s govuk-table__cell--numeric">@Currency(taxAccount.get.underpaymentAmount.getOrElse(0), 2)</td>
+                <th class="govuk-table__cell">@messages("employmenthistory.tax-account.underpayment-amount.title",
+                    s"${TaxYear.current.previous.currentYear}", s"${TaxYear.current.previous.finishYear}")
+                    <br/>
+                    <span class="govuk-hint">
+                        @messages("employmenthistory.tax-account.underpayment-amount.hint")
+                    </span>
+                </th>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@Currency(taxAccount.get.underpaymentAmount.getOrElse(0), 2)</td>
             </tr>
 
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell govuk-body-s">@messages("employmenthistory.tax-account.potential-underpayment.title",
-                    s"${TaxYear.current.previous.currentYear}",s"${TaxYear.current.previous.finishYear}")</td>
-                <td class="govuk-table__cell govuk-body-s govuk-table__cell--numeric">@Currency(taxAccount.get.actualPUPCodedInCYPlusOneTaxYear.getOrElse(0), 2)</td>
+                <th class="govuk-table__cell">@messages("employmenthistory.tax-account.potential-underpayment.title",
+                    s"${TaxYear.current.previous.currentYear}",s"${TaxYear.current.previous.finishYear}",
+                    s"${TaxYear.current.currentYear}", s"${TaxYear.current.finishYear}")
+                    <br/>
+                    <span class="govuk-hint">
+                        @messages("employmenthistory.tax-account.potential-underpayment.hint",
+                            s"${TaxYear.current.previous.currentYear}", s"${TaxYear.current.previous.finishYear}")
+                    </span>
+                </th>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@Currency(taxAccount.get.actualPUPCodedInCYPlusOneTaxYear.getOrElse(0), 2)</td>
             </tr>
 
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell govuk-body-s">
+                <th class="govuk-table__cell">
                     @messages("employmenthistory.tax-account.outstanding.debt.title",
                     s"${TaxYear.current.previous.currentYear}",s"${TaxYear.current.previous.finishYear}")
-
-                    <p><span class="govuk-caption-m govuk-!-font-size-16">@messages("employmenthistory.tax-account.outstanding.debt.text")</span></p>
-                </td>
-                <td class="govuk-table__cell govuk-body-s govuk-table__cell--numeric">@Currency(taxAccount.get.outstandingDebtRestriction.getOrElse(0), 2)</td>
+                    <br/>
+                    <span class="govuk-hint">@messages("employmenthistory.tax-account.outstanding.debt.hint")</span>
+                </th>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@Currency(taxAccount.get.outstandingDebtRestriction.getOrElse(0), 2)</td>
             </tr>
         </tbody>
     </table>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -53,7 +53,7 @@ nav.menu=Income Record Viewer menu
 ################################## Client Income Record / Employment Summary ##############################################
 employmenthistory.taxyear=Blwyddyn dreth 6 Ebrill {0} i 5 Ebrill {1}
 employmenthistory.title=Cofnod incwm cleient
-employmenthistory.header=Cofnod incwm {0}
+employmenthistory.header=Cofnod incwm
 employmenthistory.missing.client.name=cleient
 employmenthistory.nopaydata=Dim data ar gael
 employmenthistory.allowance.heading=Lwfansau
@@ -194,11 +194,14 @@ employemntHistory.select.tax.year.sidebar.change.client=Newid cleient
 
 ################################## Tax Account ####################################################
 employmenthistory.tax-account.header=Treth a dyledion a dandalwyd
-employmenthistory.tax-account.underpayment-amount.title=Treth y cadarnhawyd ei bod wedi’i thandalu, sydd wedi’i chynnwys yng nghod treth eich cleient ar gyfer blwyddyn dreth {0} i {1}, wedi’i chario drosodd o flynyddoedd blaenorol
-employmenthistory.tax-account.potential-underpayment.title=Amcangyfrif o’r dreth a dandalwyd yng nghod treth eich cleient ar gyfer y flwyddyn dreth gyfredol, sydd wedi’i chario drosodd o flwyddyn dreth {0} i {1}
-employmenthistory.tax-account.outstanding.debt.title=Dyled arall heb ei thalu, sydd wedi’i chynnwys yng nghod treth eich cleient ar gyfer blwyddyn dreth {0} i {1}, wedi’i chario drosodd o flynyddoedd treth blaenorol
-employmenthistory.tax-account.outstanding.debt.text=Gall dyledion ymwneud â Hunanasesiad, credydau treth neu Yswiriant Gwladol Dosbarth 2.
+employmenthistory.tax-account.underpayment-amount.title=Treth a dandalwyd ar gyfer blynyddoedd cynharach sydd wedi’i chynnwys yn y cod treth ar gyfer {0} i {1}
+employmenthistory.tax-account.underpayment-amount.hint=Dangosir hyn hefyd fel ‘swm y dreth a dandalwyd ar gyfer blynyddoedd cynharach’ ar P2 ‘Hysbysiad Cod TWE’ cleient.
+employmenthistory.tax-account.potential-underpayment.title=Treth a dandalwyd ar gyfer {0} i {1} sydd wedi’i chynnwys yn y cod ar gyfer {2} i {3}
+employmenthistory.tax-account.potential-underpayment.hint=Dangosir hyn hefyd fel ‘tandaliad amcangyfrifedig ar gyfer {0} i {1}’ ar P2 ‘Hysbysiad Cod TWE’ cleient.
+employmenthistory.tax-account.outstanding.debt.title=Dyled heb ei thalu sydd wedi’i chynnwys yn y cod treth ar gyfer {0} i {1}
+employmenthistory.tax-account.outstanding.debt.hint=Gall dyledion ymwneud â Hunanasesiad, credydau treth neu Yswiriant Gwladol Dosbarth 2.
 employmenthistory.tax-account.empty.text=Nid oes gan eich cleient dreth na dyledion sydd wedi’u tandalu.
+employmenthistory.tax-account.type-of-underpayment-or-debt=Y math o dandaliad neu ddyled
 
 ################################ Error Pages ###########################################################
 employmenthistory.not.authorised.title=Mae problem wedi codi

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -193,11 +193,14 @@ employemntHistory.select.tax.year.sidebar.change.client=Change client
 
 ################################## Tax Account ####################################################
 employmenthistory.tax-account.header=Underpaid tax and debts
-employmenthistory.tax-account.underpayment-amount.title=Confirmed underpaid tax included in your clients tax code for the tax year {0} to {1}, carried over from earlier years.
-employmenthistory.tax-account.potential-underpayment.title=Estimated underpaid tax in your clients tax code for the current tax, carried over from tax year {0} to {1}.
-employmenthistory.tax-account.outstanding.debt.title=Other outstanding debt included in your client''s tax code for tax year {0} to {1}, carried over from previous tax years.
-employmenthistory.tax-account.outstanding.debt.text=Debts may relate to Self Assessment, tax credits or National Insurance class 2.
+employmenthistory.tax-account.underpayment-amount.title=Underpaid tax for earlier years included in tax code for {0} to {1}
+employmenthistory.tax-account.underpayment-amount.hint=Also shown as ''amount of underpaid tax for earlier years'' on a client''s P2, ''PAYE Coding Notice''.
+employmenthistory.tax-account.potential-underpayment.title=Underpaid tax for {0} to {1} included in tax code for {2} to {3}
+employmenthistory.tax-account.potential-underpayment.hint=Also shown as ''estimated underpayment for {0} to {1}'' on a client''s P2, ''PAYE Coding Notice''.
+employmenthistory.tax-account.outstanding.debt.title=Outstanding debt included in tax code for {0} to {1}
+employmenthistory.tax-account.outstanding.debt.hint=Debts may relate to Self Assessment, tax credits or National Insurance Class 2.
 employmenthistory.tax-account.empty.text=Your client has no underpaid tax or debts.
+employmenthistory.tax-account.type-of-underpayment-or-debt=Type of underpayment or debt
 
 ################################ Error Pages ###########################################################
 employmenthistory.not.authorised.title=There is a problem

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc"            %% "domain"                           % "8.0.0-play-28",
     "uk.gov.hmrc"            %% "bootstrap-frontend-play-28"       % "5.23.0",
-    "uk.gov.hmrc"            %% "play-frontend-hmrc"               % "3.14.0-play-28",
+    "uk.gov.hmrc"            %% "play-frontend-hmrc"               % "3.15.0-play-28",
     "uk.gov.hmrc"            %% "play-partials"                    % "8.3.0-play-28",
     "uk.gov.hmrc"            %% "url-builder"                      % "3.6.0-play-28",
     "uk.gov.hmrc"            %% "agent-mtd-identifiers"            % "0.35.0-play-28",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,6 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
-addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.13")
+addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")

--- a/test/views/taxhistory/employment_summarySpec.scala
+++ b/test/views/taxhistory/employment_summarySpec.scala
@@ -141,9 +141,13 @@ class employment_summarySpec extends GuiceAppSpec with BaseViewSpec with Constan
 
       doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.underpayment-amount.title",
         s"${TaxYear.current.previous.currentYear}", s"${TaxYear.current.previous.finishYear}")).hasText mustBe true
+      doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.underpayment-amount.hint")).hasText mustBe true
       doc.getElementsContainingOwnText(oDR).hasText mustBe true
 
       doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.potential-underpayment.title",
+        s"${TaxYear.current.previous.currentYear}", s"${TaxYear.current.previous.finishYear}",
+        s"${TaxYear.current.currentYear}", s"${TaxYear.current.finishYear}")).hasText mustBe true
+      doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.potential-underpayment.hint",
         s"${TaxYear.current.previous.currentYear}", s"${TaxYear.current.previous.finishYear}")).hasText mustBe true
 
       doc.getElementsContainingOwnText(uA).hasText mustBe true
@@ -152,7 +156,7 @@ class employment_summarySpec extends GuiceAppSpec with BaseViewSpec with Constan
         s"${TaxYear.current.previous.currentYear}", s"${TaxYear.current.previous.finishYear}")).hasText mustBe true
       doc.getElementsContainingOwnText(aPC).hasText mustBe true
 
-      doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.outstanding.debt.text")).hasText mustBe true
+      doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.outstanding.debt.hint")).hasText mustBe true
       doc.getElementsContainingOwnText(Messages("employmenthistory.tax-account.header")).hasText mustBe true
 
       doc.getElementById("back-link").attr("href") mustBe "/tax-history/select-tax-year"


### PR DESCRIPTION
# DDCE-2960 - IRV Design Changes- Add in Data labels on the Underpaid tax and debts tab

- [x]  Reviewed by the design team
- [x] Acceptance tests run
- [x] Unit tests run

### Summary of changes
Removed the 2/3 div at the top of the page
Changed the Underpaid tax and debts tab as described in DDCE-2960
Updated Welsh content  

<img width="765" alt="Corrected data label 2" src="https://user-images.githubusercontent.com/369407/166720544-ccf88dca-40fa-4d82-83f5-4f790bc7048b.png">

