### PR TITLE
DDCE-2986 - Misconfigured Content Security Policy Header

### DIFF
--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -16,6 +16,7 @@
 
 @import config.AppConfig
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.helper.CSPNonce
 @import views.models.PageTitle
 
 @this(
@@ -153,10 +154,12 @@
 
 @govukTemplate(
     pageTitle = Some(title.fullTitle()),
-    headBlock = Some(hmrcHead(Some(head))),
+    headBlock = Some(hmrcHead(
+        nonce = CSPNonce.get,
+        headBlock = Some(head))),
     headerBlock = header,
     beforeContentBlock = Some(beforeContentBlock),
     footerBlock = hmrcStandardFooter(),
     mainClasses = Some("govuk-main-wrapper--auto-spacing"),
-    bodyEndBlock = Some(hmrcScripts())
+    bodyEndBlock = Some(hmrcScripts(nonce = CSPNonce.get))
 )(content)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,8 +19,6 @@ play.http.router = prod.Routes
 
 play.i18n.langs = ["en", "cy"]
 
-play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com data:"
-
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 
@@ -155,7 +153,28 @@ featureFlags {
   eyaWhatsThisFlag = true
 }
 
-play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:12345 localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com https://www.googletagmanager.com https://www.google-analytics.com https://fonts.googleapis.com https://tagmanager.google.com https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com data:;"
+play.filters.enabled += play.filters.csp.CSPFilter
+
+play.filters.csp {
+    nonce {
+        enabled = true
+        pattern = "%CSP_NONCE_PATTERN%"
+        header = true
+    }
+
+    directives {
+        base-uri = "'self'"
+        block-all-mixed-content = ""
+        child-src = "'none'"
+        connect-src = "'self' https://www.google-analytics.com https://stats.g.doubleclick.net"
+        default-src = "'none'"
+        frame-ancestors = "'self'"
+        img-src = "'self' data: https://stats.g.doubleclick.net https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com  ssl.gstatic.com www.gstatic.com https://www.google.com/ads/ga-audiences https://www.google.co.uk/ads/ga-audiences"
+        font-src = "'self' https://fonts.gstatic.com"
+        script-src = ${play.filters.csp.nonce.pattern} "'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.google-analytics.com https://tagmanager.google.com https://fonts.googleapis.com stats.g.doubleclick.net"
+        style-src = ${play.filters.csp.nonce.pattern} "'self' localhost:12345 localhost:9000 localhost:9032 localhost:9250 https://tagmanager.google.com https://fonts.googleapis.com"
+    }
+}
 
 accessibility-statement.service-path = "/income-record-viewer"
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,12 +7,12 @@ object AppDependencies {
 
   private val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"            %% "domain"                           % "8.0.0-play-28",
+    "uk.gov.hmrc"            %% "domain"                           % "8.1.0-play-28",
     "uk.gov.hmrc"            %% "bootstrap-frontend-play-28"       % "5.23.0",
     "uk.gov.hmrc"            %% "play-frontend-hmrc"               % "3.15.0-play-28",
     "uk.gov.hmrc"            %% "play-partials"                    % "8.3.0-play-28",
     "uk.gov.hmrc"            %% "url-builder"                      % "3.6.0-play-28",
-    "uk.gov.hmrc"            %% "agent-mtd-identifiers"            % "0.35.0-play-28",
+    "uk.gov.hmrc"            %% "agent-mtd-identifiers"            % "0.36.0-play-28",
     "uk.gov.hmrc"            %% "tax-year"                         % "1.7.0",
     "com.typesafe.play"      %% "play-json-joda"                   % "2.9.2"
 

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-sm --stop TAX_HISTORY_FRONTEND
-sm --stop AGENT_ACCESS_CONTROL
-sm --start AGENT_ACCESS_CONTROL -r 0.81.0
-sbt run


### PR DESCRIPTION
# DDCE-2986 - Misconfigured Content Security Policy Header

Although the [HMRC CSP Guidance](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=SEC&title=Content+Security+Policy+Guidance) does say:

> **DO NOT use data:**
> We agree with the CSP recommendation to block use of data:
> This needs to be spiked to assess what our options are and where additional work is required
> 

I could find no way to avoid this. the house svg image next to the "Agent's service home" link was being blocked.
I had tried to use a sha256 code, but it did not work.
I have read elsewhere (stackoverflow) thats there is no way that users can execute code from data from an img-src.
The code currently uses data: the ticket only mentions to not use `unsafe-inline`.

To test: 
* navigate the 8 pages in IRV inspecting the console, (in chrome -> Developer Tools > Settings labelled "Console: Preserve log on navigation".) Ensure there are no error's in the Console.
* There are no play CSP depreciation warnings when running the app

