### PR TITLE
DDCE-3001: Styling change - Tax breakdown at employment details

### DIFF
--- a/app/assets/stylesheets/taxhistory.scss
+++ b/app/assets/stylesheets/taxhistory.scss
@@ -136,3 +136,11 @@ color : #6f777b;
 .margin-inline-start {
     margin-inline-start: 0px
 }
+
+.issuedTaxCode {
+  font-family: "GDS Transport", arial, sans-serif ; font-weight: bold; display: block ; text-align:right
+}
+
+.issuedTaxCode dd {
+  font-size: 2.4em
+}

--- a/app/views/taxhistory/employment_detail.scala.html
+++ b/app/views/taxhistory/employment_detail.scala.html
@@ -237,15 +237,20 @@
 }
 @taxCodeBreakdown() = {
     @if(incomeSource.isDefined && !employment.isOccupationalPension) {
-        <h2 class="govuk-heading-m">@messages("tax.code.heading")</h2>
-        <h2 class="govuk-heading-s no-bottom-margin">@messages("tax.code.subheading")</h2>
-        <h2 class="govuk-heading-l" id="tax-code">@{
-            incomeSource.get.taxCode
-        }@{
-            ControllerUtils.displayTaxCode(incomeSource.get.basisOperation)
-        }
-        </h2>
-        <h2 class="govuk-heading-m">@messages("tax.code.allowances")</h2>
+        <h2 class="govuk-heading-l">@messages("tax.code.heading")</h2>
+        <div class="issuedTaxCode">
+            <dt class>
+                @messages("tax.code.subheading")
+            </dt>
+            <dd class id="tax-code">
+                @{
+                    incomeSource.get.taxCode
+                }@{
+                    ControllerUtils.displayTaxCode(incomeSource.get.basisOperation)
+                }
+            </dd>
+        </div>
+        <h3 class="govuk-heading-m" id="tax-code-allowances">@messages("tax.code.allowances")</h3>
         <table class="govuk-table" id="tc-allowance-table">
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
@@ -276,7 +281,7 @@
             </tbody>
         </table>
         @if(incomeSource.get.deductions.nonEmpty) {
-            <h2 class="govuk-heading-m">@messages("tax.code.deductions")</h2>
+            <h3 class="govuk-heading-m" id="tax-code-deductions">@messages("tax.code.deductions")</h3>
             <p class="govuk-body">@messages("tax.code.caveat")</p>
             <table class="govuk-table" id="tc-deduction-table">
                 <thead class="govuk-table__head">

--- a/test/views/taxhistory/employment_detailSpec.scala
+++ b/test/views/taxhistory/employment_detailSpec.scala
@@ -52,7 +52,7 @@ class employment_detailSpec extends GuiceAppSpec with BaseViewSpec with Constant
     val person: Person                                 = Person(Some(firstName), Some(surname), Some(false))
     val clientName: String                             = person.getName.getOrElse(nino)
     val incomeSourceNoDeductions: Option[IncomeSource] = Some(
-      IncomeSource(1, 1, None, List.empty, List.empty, "", None, 1, "")
+      IncomeSource(1, 1, None, List.empty, List.empty, "1100Y", None, 1, "")
     )
 
     val deductions: List[TaDeduction]                                 =
@@ -60,11 +60,22 @@ class employment_detailSpec extends GuiceAppSpec with BaseViewSpec with Constant
     val allowances: List[TaAllowance]                                 =
       List(TaAllowance(1, "test", 1.0, Some(1.0)), TaAllowance(1, "test", 1.0, Some(1.0)))
     val incomeSourceWithDeductions: Option[IncomeSource]              = Some(
-      IncomeSource(1, 1, None, deductions, List.empty, "", None, 1, "")
+      IncomeSource(1, 1, None, deductions, List.empty, "1100Y", None, 1, "")
     )
     val incomeSourceWithdeductionsAndAllowances: Option[IncomeSource] = Some(
-      IncomeSource(1, 1, None, deductions, allowances, "", None, 1, "")
+      IncomeSource(1, 1, None, deductions, allowances, "1100Y", None, 1, "")
     )
+
+    val taxCodeH2           = "#main-content > div > div > div > div > h2"
+    val taxCodeAllowancesH3 = "#tax-code-allowances"
+    val taxCodeDeductionsH3 = "#tax-code-deductions"
+    val taxCodeSubheading   = "#main-content > div > div > div > div > div > dt"
+    val taxCodeNumber       = "#main-content > div > div > div > div > div > dd"
+    val deductionsP         = "#main-content > div > div > div > div > p"
+    val noDeductions        = "#main-content > div > div > div > div > span#no-deductions"
+    val deductionsParagraph =
+      "Where an amount is owed to HMRC, a deduction is calculated to adjust the tax code so " +
+        "that the correct amount is repaid over the course of the year."
 
   }
 
@@ -310,9 +321,22 @@ class employment_detailSpec extends GuiceAppSpec with BaseViewSpec with Constant
           createEmploymentViewDetail(false, employment.employerName)
         )
 
-        doc.getElementsContainingOwnText(Messages("tax.code.heading", "")).hasText   shouldBe true
-        doc.getElementsContainingOwnText(Messages("tax.code.subheading")).hasText    shouldBe true
-        doc.getElementsContainingOwnText(Messages("tax.code.caveat")).hasText        shouldBe true
+        val expectedContent: Seq[(String, String)] =
+          Seq(
+            taxCodeH2           -> "Tax code breakdown",
+            taxCodeAllowancesH3 -> "Allowances",
+            taxCodeDeductionsH3 -> "Deductions",
+            taxCodeSubheading   -> "Latest tax code issued",
+            taxCodeNumber       -> "1100Y",
+            deductionsP         -> deductionsParagraph
+          )
+
+        expectedContent.foreach { case (cssSelector, desiredContent) =>
+          doc.select(cssSelector).text() shouldBe desiredContent
+        }
+
+        doc.getElementById("tax-code-allowances").tagName()                          shouldBe "h3"
+        doc.getElementById("tax-code-deductions").tagName()                          shouldBe "h3"
         doc.getElementsContainingOwnText(Messages("tax.code.no.deductions")).hasText shouldBe false
 
       }
@@ -331,9 +355,19 @@ class employment_detailSpec extends GuiceAppSpec with BaseViewSpec with Constant
           createEmploymentViewDetail(false, employment.employerName)
         )
 
-        doc.getElementsContainingOwnText(Messages("tax.code.heading", "")).hasText   shouldBe true
-        doc.getElementsContainingOwnText(Messages("tax.code.subheading")).hasText    shouldBe true
-        doc.getElementsContainingOwnText(Messages("tax.code.no.deductions")).hasText shouldBe true
+        val expectedContent: Seq[(String, String)] =
+          Seq(
+            taxCodeH2           -> "Tax code breakdown",
+            taxCodeAllowancesH3 -> "Allowances",
+            taxCodeSubheading   -> "Latest tax code issued",
+            taxCodeNumber       -> "1100Y",
+            noDeductions        -> "There are no deductions."
+          )
+
+        expectedContent.foreach { case (cssSelector, desiredContent) =>
+          doc.select(cssSelector).text() shouldBe desiredContent
+        }
+        doc.getElementById("tax-code-allowances").tagName() shouldBe "h3"
 
       }
     }
@@ -505,4 +539,5 @@ class employment_detailSpec extends GuiceAppSpec with BaseViewSpec with Constant
     doc.getElementById("nav-year").text         shouldBe Messages("nav.year")
     doc.getElementById("nav-home").attr("href") shouldBe appConfig.agentAccountHomePage
   }
+
 }


### PR DESCRIPTION
## DDCE-3001: Styling change - Tax breakdown at employment details
Allowances heading is now a H3 
Deductions heading is now a H3
Right aligned the tax code and latest tax code
Instruction to change Tax Breakdown to H2. This was already a H2, have set `class="govuk-heading-l"` from `class="govuk-heading-m"` to match prototype screenshot provided.
Dependencies checked in DDCE-3004

 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 
#### Result
[DDCE-3001_single-record_en](https://user-images.githubusercontent.com/87376121/198564200-618aaa40-130d-405b-a23c-06deb1bd089c.png)
[DDCE 3001_single-record_cy](https://user-images.githubusercontent.com/87376121/198564209-d7c2f6a0-94ba-4c7d-9a4f-cf0f4c3ea4d7.png)
 