### PR TITLE
DDCE-3564: Upgrade to Scala 2.13

### DIFF
--- a/app/controllers/ConfirmDetailsController.scala
+++ b/app/controllers/ConfirmDetailsController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import config.AppConfig
 import connectors.CitizenDetailsConnector
-import javax.inject.Inject
+import controllers.BaseController
 import play.api.mvc._
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.auth.core.AuthConnector
@@ -26,6 +26,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import views.html.taxhistory.confirm_details
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ConfirmDetailsController @Inject() (

--- a/app/controllers/EmploymentDetailController.scala
+++ b/app/controllers/EmploymentDetailController.scala
@@ -58,7 +58,7 @@ class EmploymentDetailController @Inject() (
       case Left(citizenStatus) => redirectToClientErrorPage(citizenStatus)
       case Right(person)       =>
         taxHistoryConnector.getEmployment(nino, taxYear, employmentId) flatMap { empDetailsResponse =>
-          empDetailsResponse.status match {
+          (empDetailsResponse.status: @unchecked) match {
             case OK                                                      =>
               loadEmploymentDetailsPage(empDetailsResponse, nino, taxYear, employmentId, person)
             case NOT_FOUND                                               =>

--- a/app/controllers/EmploymentDetailController.scala
+++ b/app/controllers/EmploymentDetailController.scala
@@ -18,19 +18,18 @@ package controllers
 
 import config.AppConfig
 import connectors.{CitizenDetailsConnector, TaxHistoryConnector}
-
-import javax.inject.Inject
+import controllers.BaseController
 import model.api.IncomeSource._
 import model.api._
 import models.taxhistory.Person
 import play.api.i18n.Messages
-import play.api.mvc.{MessagesControllerComponents, _}
+import play.api.mvc._
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import views.models.EmploymentViewDetail
 import utils.DateUtils
+import views.models.EmploymentViewDetail
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/controllers/EmploymentSummaryController.scala
+++ b/app/controllers/EmploymentSummaryController.scala
@@ -79,7 +79,7 @@ class EmploymentSummaryController @Inject() (
     taxHistoryConnector
       .getEmploymentsAndPensions(ninoField, taxYear)
       .flatMap { empResponse =>
-        empResponse.status match {
+        (empResponse.status: @unchecked) match {
           case OK                                                      =>
             val employments: List[Employment] = getEmploymentsFromResponse(empResponse)
               .filterNot(emp => emp.employerName.equalsIgnoreCase(noRecordHeld))

--- a/app/controllers/EmploymentSummaryController.scala
+++ b/app/controllers/EmploymentSummaryController.scala
@@ -18,6 +18,7 @@ package controllers
 
 import config.AppConfig
 import connectors.{CitizenDetailsConnector, TaxHistoryConnector}
+import controllers.BaseController
 import model.api._
 import models.taxhistory.Person
 import play.api.i18n.Messages

--- a/app/controllers/SelectTaxYearController.scala
+++ b/app/controllers/SelectTaxYearController.scala
@@ -66,7 +66,7 @@ class SelectTaxYearController @Inject() (
     clientName: Option[String]
   )(implicit hc: HeaderCarrier, request: Request[_]): Future[Result] =
     taxHistoryConnector.getTaxYears(nino) map { taxYearResponse =>
-      taxYearResponse.status match {
+      (taxYearResponse.status: @unchecked) match {
         case OK                                                      =>
           val taxYears = getTaxYears(taxYearResponse.json.as[List[IndividualTaxYear]])
           httpStatus(selectTaxYear(form, taxYears, clientName, nino.toString))

--- a/app/controllers/SelectTaxYearController.scala
+++ b/app/controllers/SelectTaxYearController.scala
@@ -18,6 +18,7 @@ package controllers
 
 import config.AppConfig
 import connectors.{CitizenDetailsConnector, TaxHistoryConnector}
+import controllers.BaseController
 import form.SelectTaxYearForm.selectTaxYearForm
 import model.api.IndividualTaxYear
 import models.taxhistory.SelectTaxYear

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -44,7 +44,7 @@
 
     @if(timeoutActive) {
         @hmrcTimeoutDialogHelper(
-            signOutUrl = routes.EmploymentSummaryController.logout.url,
+            signOutUrl = routes.EmploymentSummaryController.logout().url,
             keepAliveUrl = Some(controllers.routes.SignedOutController.keepAlive().url),
             timeoutUrl =  Some(controllers.routes.SignedOutController.signedOut().url),
             timeout = Some(appConfig.timeout),

--- a/app/views/taxhistory/SignedOut.scala.html
+++ b/app/views/taxhistory/SignedOut.scala.html
@@ -31,7 +31,7 @@
         <h1 class="govuk-heading-xl">@messages("signedOut.title")</h1>
 
         <div>
-            <a class="govuk-button" role="button" href="@routes.EmploymentSummaryController.signIn">@messages("signedOut.signIn")</a>
+            <a class="govuk-button" role="button" href="@routes.EmploymentSummaryController.signIn()">@messages("signedOut.signIn")</a>
         </div>
     }
 }

--- a/app/views/taxhistory/confirm_details.scala.html
+++ b/app/views/taxhistory/confirm_details.scala.html
@@ -65,7 +65,7 @@
                         attributes = Map("id" -> "confirm-and-continue-button")
                     )
                 )
-                <a href="@routes.SelectClientController.getSelectClientPage" class="govuk-link" id="cancel-link">@messages("employmenthistory.confirm.details.cancel")</a>
+                <a href="@routes.SelectClientController.getSelectClientPage()" class="govuk-link" id="cancel-link">@messages("employmenthistory.confirm.details.cancel")</a>
             </div>
 
         }

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings.{defaultSettings, scalaSettings}
-import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
+import uk.gov.hmrc.DefaultBuildSettings._
 
 val appName = "tax-history-frontend"
 
@@ -9,7 +8,6 @@ lazy val microservice = Project(appName, file("."))
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
     majorVersion := 3,
-    scalaSettings,
     scalaVersion := "2.13.10",
     libraryDependencies ++= AppDependencies(),
     // To resolve a bug with version 2.x.x of the scoverage plugin - https://github.com/sbt/sbt/issues/6997
@@ -19,7 +17,7 @@ lazy val microservice = Project(appName, file("."))
     defaultSettings(),
     retrieveManaged := true,
     ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;.*AuthService.*;modgiels/.data/..*;controllers.auth.*;filters.*;forms.*;config.*;" +
-      ".*BuildInfo.*;.*helpers.*;.*Routes.*;controllers.ExampleController;controllers.testonly.TestOnlyController",
+      ".*BuildInfo.*;.*helpers.*;.*Routes.*;controllers.testonly.TestOnlyController",
     ScoverageKeys.coverageMinimumStmtTotal := 95,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
@@ -37,5 +35,5 @@ lazy val microservice = Project(appName, file("."))
     )
   )
 
-addCommandAlias("scalafmtAll", "all scalafmtSbt scalafmt test:scalafmt")
-addCommandAlias("scalastyleAll", "all scalastyle test:scalastyle")
+addCommandAlias("scalafmtAll", "all scalafmtSbt scalafmt Test/scalafmt")
+addCommandAlias("scalastyleAll", "all scalastyle Test/scalastyle")

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val microservice = Project(appName, file("."))
     retrieveManaged := true,
     ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;.*AuthService.*;modgiels/.data/..*;controllers.auth.*;filters.*;forms.*;config.*;" +
       ".*BuildInfo.*;.*helpers.*;.*Routes.*;controllers.testonly.TestOnlyController",
-    ScoverageKeys.coverageMinimumStmtTotal := 95,
+    ScoverageKeys.coverageMinimumStmtTotal := 97,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,10 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     majorVersion := 3,
     scalaSettings,
-    scalaVersion := "2.12.16",
+    scalaVersion := "2.13.10",
     libraryDependencies ++= AppDependencies(),
+    // To resolve a bug with version 2.x.x of the scoverage plugin - https://github.com/sbt/sbt/issues/6997
+    libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
     name := appName,
     PlayKeys.playDefaultPort := 9996,
     defaultSettings(),

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,12 +3,12 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "7.13.0"
+  private val bootstrapPlayVersion = "7.14.0"
 
   private val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "6.4.0-play-28",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "6.7.0-play-28",
     "uk.gov.hmrc" %% "play-partials"              % "8.3.0-play-28",
     "uk.gov.hmrc" %% "domain"                     % "8.1.0-play-28",
     "uk.gov.hmrc" %% "tax-year"                   % "3.0.0"
@@ -16,7 +16,7 @@ object AppDependencies {
 
   private val test: Seq[ModuleID] = Seq(
     "org.scalatest"       %% "scalatest"               % "3.2.15",
-    "org.jsoup"            % "jsoup"                   % "1.15.3",
+    "org.jsoup"            % "jsoup"                   % "1.15.4",
     "com.typesafe.play"   %% "play-test"               % PlayVersion.current,
     "org.mockito"         %% "mockito-scala-scalatest" % "1.17.12",
     "uk.gov.hmrc"         %% "bootstrap-test-play-28"  % bootstrapPlayVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
     "uk.gov.hmrc" %% "play-frontend-hmrc"         % "6.4.0-play-28",
     "uk.gov.hmrc" %% "play-partials"              % "8.3.0-play-28",
-    "uk.gov.hmrc" %% "agent-mtd-identifiers"      % "0.60.0-play-28",
+    "uk.gov.hmrc" %% "domain"                     % "8.1.0-play-28",
     "uk.gov.hmrc" %% "tax-year"                   % "3.0.0"
   )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,8 +8,8 @@ object AppDependencies {
   private val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "6.7.0-play-28",
-    "uk.gov.hmrc" %% "play-partials"              % "8.3.0-play-28",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "6.8.0-play-28",
+    "uk.gov.hmrc" %% "play-partials"              % "8.4.0-play-28",
     "uk.gov.hmrc" %% "domain"                     % "8.1.0-play-28",
     "uk.gov.hmrc" %% "tax-year"                   % "3.0.0"
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.0.7")
 
-addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle"     % "1.5.1")
+addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle" % "1.5.1")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,20 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
-resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
+resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
   Resolver.ivyStylePatterns
+)
+
+// To resolve a bug with version 2.x.x of the scoverage plugin - https://github.com/sbt/sbt/issues/6997
+// Try to remove when sbt 1.8.0+ and scoverage is 2.0.7+
+
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.0.0")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.0.7")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle"     % "1.5.1")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
@@ -17,4 +24,4 @@ addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sbt clean scalafmtAll scalastyleAll compile coverage test coverageOff coverageReport dependencyUpdates
+sbt clean scalafmtAll scalastyleAll compile coverage Test/test coverageOff coverageReport dependencyUpdates

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -20,12 +20,10 @@ import config.AppConfig
 import models.taxhistory.Person
 import org.mockito.ArgumentMatchers.any
 import org.scalatest.concurrent.ScalaFutures
-import play.api.http.Status
 import play.api.libs.json.JsValue
 import play.api.mvc.{MessagesControllerComponents, Result, Results}
 import play.api.test.Helpers._
 import play.api.{Configuration, Environment}
-import support.fixtures.ControllerFixture
 import support.{BaseSpec, ControllerSpec}
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
@@ -81,7 +79,7 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
         hc,
         fakeRequest.withSession("USER_NINO" -> nino)
       )
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(controller.appConfig.agentSubscriptionStart)
     }
 
@@ -100,7 +98,7 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
         hc,
         fakeRequest.withSession("USER_NINO" -> nino)
       )
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
         controllers.routes.ClientErrorController.getNoAgentServicesAccountPage().url
       )
@@ -114,14 +112,14 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
         )
       )
         .thenReturn(
-          Future.successful(new ~[Option[AffinityGroup], Enrolments](Some(AffinityGroup.Individual), Enrolments(Set())))
+          Future.successful(new ~[Option[AffinityGroup], Enrolments](None, Enrolments(Set())))
         )
 
       val result: Future[Result] = controller.authorisedForAgent(_ => Future.successful(Results.Ok("test")))(
         hc,
         fakeRequest.withSession("USER_NINO" -> nino)
       )
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
         controllers.routes.ClientErrorController.getNoAgentServicesAccountPage().url
       )
@@ -140,7 +138,7 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
         hc,
         fakeRequest.withSession("USER_NINO" -> nino)
       )
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getTechnicalError().url)
     }
 
@@ -157,7 +155,7 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
         hc,
         fakeRequest.withSession("USER_NINO" -> nino)
       )
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result).get should include("/bas-gateway/sign-in")
     }
 
@@ -174,7 +172,7 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
         hc,
         fakeRequest.withSession("USER_NINO" -> nino)
       )
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result).get should include("/bas-gateway/sign-in")
     }
 
@@ -191,7 +189,7 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
         hc,
         fakeRequest.withSession("USER_NINO" -> nino)
       )
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result).get should include("/bas-gateway/sign-in")
     }
 
@@ -208,34 +206,42 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
         hc,
         fakeRequest.withSession("USER_NINO" -> nino)
       )
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getNotAuthorised().url)
     }
   }
 
   "show not found error page when 404 returned from connector" in new TestSetup {
     val taxYear                = 2017
-    val result: Future[Result] = Future(controller.handleHttpFailureResponse(Status.NOT_FOUND, Some(taxYear)))
-    status(result)           shouldBe Status.SEE_OTHER
+    val result: Future[Result] = Future(controller.handleHttpFailureResponse(NOT_FOUND, Some(taxYear)))
+    status(result)           shouldBe SEE_OTHER
     redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getNoData(taxYear).url)
   }
 
   "show not authorised error page when 401 returned from connector" in new TestSetup {
-    val result: Future[Result] = Future(controller.handleHttpFailureResponse(Status.UNAUTHORIZED))
-    status(result)           shouldBe Status.SEE_OTHER
+    val result: Future[Result] = Future(controller.handleHttpFailureResponse(UNAUTHORIZED))
+    status(result)           shouldBe SEE_OTHER
     redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getNotAuthorised().url)
   }
 
-  "show technical error page when any response other than 200, 401, 404 returned from connector" in new TestSetup {
-    val result: Future[Result] = Future(controller.handleHttpFailureResponse(Status.INTERNAL_SERVER_ERROR))
-    status(result)           shouldBe Status.SEE_OTHER
-    redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getTechnicalError().url)
+  "show technical error page" when {
+    "404 with no taxYear is returned from connector" in new TestSetup {
+      val result: Future[Result] = Future(controller.handleHttpFailureResponse(NOT_FOUND, None))
+      status(result)           shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getTechnicalError().url)
+    }
+
+    "any response other than 200, 401, 404 returned from connector" in new TestSetup {
+      val result: Future[Result] = Future(controller.handleHttpFailureResponse(INTERNAL_SERVER_ERROR))
+      status(result)           shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getTechnicalError().url)
+    }
   }
 
   "Sign out" must {
     "redirect to feed back survey link" in new TestSetup {
       val result: Future[Result] = controller.logout()(fakeRequest)
-      status(result)           shouldBe Status.SEE_OTHER
+      status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(controller.appConfig.serviceSignOut)
     }
 
@@ -262,25 +268,30 @@ class BaseControllerSpec extends ControllerSpec with BaseSpec with ScalaFutures 
     }
   }
 
-  "retrieveCitizenDetails" when {
+  "retrieveCitizenDetails" should {
 
-    "The deceased flag is true" in new TestSetup {
+    "return Left(GONE) when the deceased flag is true" in new TestSetup {
       val json: JsValue    = loadFile("/json/model/api/personDeceasedTrue.json")
-      val hr: HttpResponse = HttpResponse(Status.OK, json = json, Map.empty)
+      val hr: HttpResponse = HttpResponse(OK, json = json, Map.empty)
       await(controller.retrieveCitizenDetails(Future(hr))) shouldBe Left(GONE)
     }
 
-    "The deceased flag is false" in new TestSetup with ControllerFixture {
+    "return Right(person) when the deceased flag is false" in new TestSetup {
       val json: JsValue    = loadFile("/json/model/api/personDeceasedFalse.json")
-      val hr: HttpResponse = HttpResponse(Status.OK, json = json, Map.empty)
-      await(controller.retrieveCitizenDetails(Future(hr))) shouldBe Right(person.get)
+      val hr: HttpResponse = HttpResponse(OK, json = json, Map.empty)
+      val person: Person   = Person(Some("first name"), Some("second name"), Some(false))
+      await(controller.retrieveCitizenDetails(Future(hr))) shouldBe Right(person)
     }
 
-    "The deceased flag is not given" in new TestSetup {
+    "return Right(person) when the deceased flag is not given" in new TestSetup {
       val json: JsValue    = loadFile("/json/model/api/personDeceasedNoValue.json")
-      val hr: HttpResponse = HttpResponse(Status.OK, json = json, Map.empty)
-      val person           = Person(Some("first name"), Some("second name"), None)
+      val hr: HttpResponse = HttpResponse(OK, json = json, Map.empty)
+      val person: Person   = Person(Some("first name"), Some("second name"), None)
       await(controller.retrieveCitizenDetails(Future(hr))) shouldBe Right(person)
+    }
+
+    "return Left(BAD_REQUEST) when there is an exception" in new TestSetup {
+      await(controller.retrieveCitizenDetails(Future.failed(new Exception))) shouldBe Left(BAD_REQUEST)
     }
   }
 

--- a/test/controllers/ConfirmDetailsControllerSpec.scala
+++ b/test/controllers/ConfirmDetailsControllerSpec.scala
@@ -64,7 +64,7 @@ class ConfirmDetailsControllerSpec extends ControllerSpec with BaseSpec {
 
   "ConfirmDetailsController" must {
 
-    "successfully load confirm details page when citizen details returns 200 OK" in new Setup {
+    "successfully load confirm details page with name when citizen details returns 200 OK" in new Setup {
       implicit val request: Request[_] = fakeRequest
 
       when(controller.citizenDetailsConnector.getPersonDetails(argEq(Nino(nino)))(any[HeaderCarrier]))
@@ -72,6 +72,23 @@ class ConfirmDetailsControllerSpec extends ControllerSpec with BaseSpec {
 
       val result: Future[Result] = controller.getConfirmDetailsPage()(fakeRequestWithNino)
       val expectedView: Html     = inject[confirm_details].apply(name, nino)
+
+      status(result) shouldBe OK
+      result.rendersTheSameViewAs(expectedView)
+    }
+
+    "successfully load confirm details page with no name when citizen details returns 200 OK" in new Setup {
+      implicit val request: Request[_] = fakeRequest
+
+      when(controller.citizenDetailsConnector.getPersonDetails(argEq(Nino(nino)))(any[HeaderCarrier]))
+        .thenReturn(
+          Future.successful(
+            HttpResponse(status = OK, json = Json.toJson(Person(None, None, Some(false))), headers = Map.empty)
+          )
+        )
+
+      val result: Future[Result] = controller.getConfirmDetailsPage()(fakeRequestWithNino)
+      val expectedView: Html     = inject[confirm_details].apply(nino, nino)
 
       status(result) shouldBe OK
       result.rendersTheSameViewAs(expectedView)

--- a/test/controllers/SelectClientControllerSpec.scala
+++ b/test/controllers/SelectClientControllerSpec.scala
@@ -18,7 +18,6 @@ package controllers
 
 import form.SelectClientForm.selectClientForm
 import org.mockito.ArgumentMatchers.any
-import play.api.http.Status
 import play.api.mvc.{Request, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -67,7 +66,7 @@ class SelectClientControllerSpec extends ControllerSpec with BaseSpec {
       implicit val request: Request[_] = FakeRequest()
       val result: Future[Result]       = controller.getSelectClientPage()(fakeRequest)
       val expectedView: select_client  = app.injector.instanceOf[select_client]
-      status(result) shouldBe Status.OK
+      status(result) shouldBe OK
       result rendersTheSameViewAs expectedView(selectClientForm)
     }
 
@@ -85,7 +84,7 @@ class SelectClientControllerSpec extends ControllerSpec with BaseSpec {
             .withFormUrlEncodedBody(invalidSelectClientForm: _*)
             .withMethod("POST")
         )
-      status(result) shouldBe Status.BAD_REQUEST
+      status(result) shouldBe BAD_REQUEST
     }
 
     "successfully redirect to next page when valid nino is supplied as input" in new LocalSetup {
@@ -98,8 +97,15 @@ class SelectClientControllerSpec extends ControllerSpec with BaseSpec {
         controller
           .submitSelectClientPage()
           .apply(FakeRequest().withFormUrlEncodedBody(validSelectClientForm: _*).withMethod("POST"))
-      status(result)           shouldBe Status.SEE_OTHER
+      status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.ConfirmDetailsController.getConfirmDetailsPage().url)
+    }
+
+    "successfully redirects to itself" in new LocalSetup {
+      val result: Future[Result] = controller.root()(fakeRequest)
+
+      status(result)           shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(routes.SelectClientController.getSelectClientPage().url)
     }
   }
 

--- a/test/controllers/SelectTaxYearControllerSpec.scala
+++ b/test/controllers/SelectTaxYearControllerSpec.scala
@@ -22,7 +22,6 @@ import model.api.IndividualTaxYear
 import models.taxhistory.SelectTaxYear
 import org.mockito.ArgumentMatchers.{any, eq => argEq}
 import play.api.data.Form
-import play.api.http.Status
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Result
@@ -93,51 +92,51 @@ class SelectTaxYearControllerSpec extends ControllerSpec with ControllerFixture 
       val result: Future[Result] =
         controller.getSelectTaxYearPage().apply(fakeRequestWithNino.withMethod("POST"))
 
-      status(result)          shouldBe Status.OK
+      status(result)          shouldBe OK
       contentAsString(result) shouldBe
         view(validForm, List("2015" -> "2015 to 2016"), name, nino)(fakeRequestWithNino, messages, appConfig).toString()
     }
 
     "redirect to technical error page when getTaxYears returns status internal server error" in new LocalSetup {
       when(controller.taxHistoryConnector.getTaxYears(argEq(Nino(nino)))(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(Status.INTERNAL_SERVER_ERROR, "")))
+        .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, "")))
 
       val result: Future[Result] =
         controller.getSelectTaxYearPage().apply(FakeRequest().withSession("USER_NINO" -> nino).withMethod("POST"))
 
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.ClientErrorController.getTechnicalError().url)
     }
 
     "redirect to technical error page when getTaxYears returns 4xx status" in new LocalSetup {
       when(controller.taxHistoryConnector.getTaxYears(argEq(Nino(nino)))(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(Status.BAD_REQUEST, "")))
+        .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, "")))
 
       val result: Future[Result] =
         controller.getSelectTaxYearPage().apply(FakeRequest().withSession("USER_NINO" -> nino).withMethod("POST"))
 
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.ClientErrorController.getTechnicalError().url)
     }
 
     "redirect to technical error page when getTaxYears returns 3xx status" in new LocalSetup {
       when(controller.taxHistoryConnector.getTaxYears(argEq(Nino(nino)))(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(Status.SEE_OTHER, "")))
+        .thenReturn(Future.successful(HttpResponse(SEE_OTHER, "")))
 
       val result: Future[Result] =
         controller.getSelectTaxYearPage().apply(FakeRequest().withSession("USER_NINO" -> nino).withMethod("POST"))
 
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.ClientErrorController.getTechnicalError().url)
     }
 
     "return not found error page when citizen details returns locked status 423" in new LocalSetup {
       when(controller.citizenDetailsConnector.getPersonDetails(argEq(Nino(nino)))(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(Status.LOCKED, "")))
+        .thenReturn(Future.successful(HttpResponse(LOCKED, "")))
 
       val result: Future[Result] =
         controller.getSelectTaxYearPage().apply(FakeRequest().withSession("USER_NINO" -> nino).withMethod("POST"))
-      status(result) shouldBe Status.SEE_OTHER
+      status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(controllers.routes.ClientErrorController.getMciRestricted().url)
     }
 
@@ -158,8 +157,25 @@ class SelectTaxYearControllerSpec extends ControllerSpec with ControllerFixture 
             .withMethod("POST")
         )
 
-      status(result)           shouldBe Status.SEE_OTHER
+      status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.EmploymentSummaryController.getTaxHistory(taxYear2016).url)
+    }
+
+    "redirect to select client page when there is no nino in session and submission made with invalid data" in new LocalSetup {
+      val invalidSelectTaxYearForm = Seq(
+        "selectTaxYear" -> ""
+      )
+
+      val result: Future[Result] = controller
+        .submitSelectTaxYearPage()
+        .apply(
+          FakeRequest()
+            .withFormUrlEncodedBody(invalidSelectTaxYearForm: _*)
+            .withMethod("POST")
+        )
+
+      status(result)           shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(routes.SelectClientController.getSelectClientPage().url)
     }
 
     "fail submission on invalid data" in new LocalSetup {
@@ -175,7 +191,7 @@ class SelectTaxYearControllerSpec extends ControllerSpec with ControllerFixture 
             .withFormUrlEncodedBody(validSelectTaxYearForm: _*)
             .withMethod("POST")
         )
-      status(result) shouldBe Status.BAD_REQUEST
+      status(result) shouldBe BAD_REQUEST
       contentAsString(result) should include(Messages("employmenthistory.select.tax.year.error.message"))
     }
 
@@ -184,7 +200,7 @@ class SelectTaxYearControllerSpec extends ControllerSpec with ControllerFixture 
         "selectTaxYear" -> ""
       )
       when(controller.taxHistoryConnector.getTaxYears(argEq(Nino(nino)))(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse(Status.INTERNAL_SERVER_ERROR, "")))
+        .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR, "")))
 
       val result: Future[Result] = controller
         .submitSelectTaxYearPage()
@@ -195,7 +211,7 @@ class SelectTaxYearControllerSpec extends ControllerSpec with ControllerFixture 
             .withMethod("POST")
         )
 
-      status(result)           shouldBe Status.SEE_OTHER
+      status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.ClientErrorController.getTechnicalError().url)
     }
   }

--- a/test/forms/SelectClientFormSpec.scala
+++ b/test/forms/SelectClientFormSpec.scala
@@ -17,6 +17,7 @@
 package forms
 
 import form.SelectClientForm.selectClientForm
+import models.taxhistory.SelectClient
 import play.api.data.FormError
 import play.api.libs.json.Json
 import support.BaseSpec
@@ -36,6 +37,15 @@ class SelectClientFormSpec extends BaseSpec with TestUtil {
       val validatedForm = selectClientForm.bind(postData, maxChar)
       val errors        = validatedForm.errors
       errors shouldBe empty
+    }
+
+    "return the correct result when filled" in {
+      val postData      = Json.obj(
+        "clientId" -> nino
+      )
+      val validatedForm = selectClientForm.bind(postData, maxChar)
+
+      selectClientForm.fill(SelectClient(nino)) shouldBe validatedForm
     }
 
     "return an invalid length error when no nino is entered" in {

--- a/test/forms/SelectTaxYearFormSpec.scala
+++ b/test/forms/SelectTaxYearFormSpec.scala
@@ -17,6 +17,7 @@
 package forms
 
 import form.SelectTaxYearForm.selectTaxYearForm
+import models.taxhistory.SelectTaxYear
 import play.api.data.FormError
 import play.api.libs.json.Json
 import support.BaseSpec
@@ -36,6 +37,15 @@ class SelectTaxYearFormSpec extends BaseSpec with TestUtil {
       val validatedForm = selectTaxYearForm.bind(postData, maxChar)
       val errors        = validatedForm.errors
       errors shouldBe empty
+    }
+
+    "return the correct result when filled" in {
+      val postData      = Json.obj(
+        "selectTaxYear" -> "2016"
+      )
+      val validatedForm = selectTaxYearForm.bind(postData, maxChar)
+
+      selectTaxYearForm.fill(SelectTaxYear(Some("2016"))) shouldBe validatedForm
     }
 
     "return an invalid length error when no tax year is selected" in {

--- a/test/model/api/EmploymentPaymentTypeSpec.scala
+++ b/test/model/api/EmploymentPaymentTypeSpec.scala
@@ -70,6 +70,14 @@ class EmploymentPaymentTypeSpec extends BaseSpec {
       format.reads(JsNumber(bigDec)) shouldBe a[JsError]
     }
 
+    "extract the names" in {
+      unapply(OccupationalPension)           shouldBe Some("OccupationalPension")
+      unapply(JobseekersAllowance)           shouldBe Some("JobseekersAllowance")
+      unapply(IncapacityBenefit)             shouldBe Some("IncapacityBenefit")
+      unapply(EmploymentAndSupportAllowance) shouldBe Some("EmploymentAndSupportAllowance")
+      unapply(Unknown)                       shouldBe Some("Unknown")
+    }
+
   }
 
 }

--- a/test/utils/CurrencySpec.scala
+++ b/test/utils/CurrencySpec.scala
@@ -73,5 +73,21 @@ class CurrencySpec extends PlaySpec {
     "add extra 0 when there is 1 number after the decimal point" in {
       Currency(BigDecimal(101.1)).toString must be("£101.10")
     }
+
+    "convert BigDecimal to Currency value successfully when using fromBD" in {
+      Currency.fromBD(100.55) must be(Currency(BigDecimal(100.55)))
+    }
+
+    "convert Int to Currency value successfully when using fromBD" in {
+      Currency.fromInt(3) must be(Currency(BigDecimal(3.00)))
+    }
+
+    "convert Currency to Double value successfully when using currencyToDouble" in {
+      Currency.currencyToDouble(Currency(BigDecimal(100.55))) must be(100.55.doubleValue())
+    }
+
+    "convert Currency to Float value successfully when using currencyToFloat" in {
+      Currency.currencyToFloat(Currency(BigDecimal(100.55))) must be(100.55.floatValue())
+    }
   }
 }

--- a/test/views/Fixture.scala
+++ b/test/views/Fixture.scala
@@ -24,7 +24,7 @@ import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import views.Strings.TextHelpers
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 trait Fixture extends Matchers {

--- a/test/views/errors/deceasedSpec.scala
+++ b/test/views/errors/deceasedSpec.scala
@@ -33,7 +33,7 @@ class deceasedSpec extends GuiceAppSpec with BaseViewSpec {
 
     "have correct title and heading page view" in new Fixture {
 
-      val view: HtmlFormat.Appendable = inject[deceased].apply
+      val view: HtmlFormat.Appendable = inject[deceased].apply()
 
       doc.title mustBe expectedPageTitle(messages("employmenthistory.deceased.title"))
       doc.getElementById("back-link").attr("href") mustBe "/tax-history/select-client"

--- a/test/views/errors/mci_restrictedSpec.scala
+++ b/test/views/errors/mci_restrictedSpec.scala
@@ -38,7 +38,7 @@ class mci_restrictedSpec extends GuiceAppSpec with BaseViewSpec {
 
     "have correct title and heading page view event" in new ViewFixture {
 
-      val view: HtmlFormat.Appendable = inject[mci_restricted].apply
+      val view: HtmlFormat.Appendable = inject[mci_restricted].apply()
 
       doc.title mustBe expectedPageTitle(messages("employmenthistory.mci.restricted.title"))
       doc.getElementById("back-link").attr("href") mustBe "/tax-history/select-client"

--- a/test/views/errors/no_agent_services_accountSpec.scala
+++ b/test/views/errors/no_agent_services_accountSpec.scala
@@ -30,7 +30,7 @@ class no_agent_services_accountSpec extends GuiceAppSpec with BaseViewSpec {
 
   "no agent services account view" must {
     "have correct title and heading page view event" in new Fixture {
-      val view: HtmlFormat.Appendable = inject[no_agent_services_account].apply
+      val view: HtmlFormat.Appendable = inject[no_agent_services_account].apply()
       doc.title mustBe expectedPageTitle(messages("employmenthistory.no.agent.services.account.title"))
     }
   }

--- a/test/views/errors/technical_errorSpec.scala
+++ b/test/views/errors/technical_errorSpec.scala
@@ -33,7 +33,7 @@ class technical_errorSpec extends GuiceAppSpec with BaseViewSpec {
 
     "have correct title, heading and GA page view event" in new Fixture {
 
-      val view: HtmlFormat.Appendable = inject[technical_error].apply
+      val view: HtmlFormat.Appendable = inject[technical_error].apply()
 
       doc.title mustBe expectedPageTitle(messages("employmenthistory.technical.error.title"))
       doc.getElementById("back-link").attr("href").contains(appConfig.agentAccountHomePage) mustBe true


### PR DESCRIPTION
### DDCE-3564: Upgrade to Scala 2.13

- Updated Scala and dependencies
- Run AT locally
- Replaced uk.gov.hmrc.agent-mtd-identifiers with uk.gov.hmrc.domain
- Also check build-jobs and service-manager-config updates below