### PR TITLE
DDCE-3454: Change table to description list in employment single-records

### DIFF
--- a/app/assets/stylesheets/taxhistory.scss
+++ b/app/assets/stylesheets/taxhistory.scss
@@ -157,3 +157,25 @@ color : #6f777b;
 #tax-code-allowances {
   padding-top: 0;
 }
+
+@media only screen and (min-width: 227px) and (max-width: 640px) {
+  #pay-and-tax-list dd {
+    text-align: right;
+    word-wrap: normal;
+  }
+
+  #pay-and-tax-list dt {
+    float: left;
+    clear: left;
+  }
+}
+
+@media only screen and (min-width: 641px) {
+  #pay-and-tax-list dd {
+    text-align: right;
+  }
+
+  #pay-and-tax-list dt {
+    width: 40%;
+  }
+}

--- a/app/views/taxhistory/employment_detail.scala.html
+++ b/app/views/taxhistory/employment_detail.scala.html
@@ -81,8 +81,8 @@
 
     <dl class="govuk-summary-list">
         @if(!employment.isJobseekersAllowance) {
-                <dt class="govuk-body-s govuk-!-font-weight-bold no-bottom-margin">@messages("lbl.paye.reference")</dt>
-                <dd class="govuk-body-s margin-inline-start">@employment.payeReference</dd>
+            <dt class="govuk-body-s govuk-!-font-weight-bold no-bottom-margin">@messages("lbl.paye.reference")</dt>
+            <dd class="govuk-body-s margin-inline-start">@employment.payeReference</dd>
 
         }
         @if(!employment.isOccupationalPension && !employment.isJobseekersAllowance) {
@@ -100,23 +100,34 @@
 @payments() = {
     @payAndTaxOpt match {
         case Some(payAndTax) => {
-            <table class="govuk-table" id="pay-and-tax-table">
-                <tr class="govuk-table__row">
-                    <th class="govuk-table__header">@messages("lbl.taxable.income")</th>
-                    <td class="govuk-table__cell govuk-table__cell--numeric">@payAndTax.taxablePayTotalIncludingEYU.map(Currency(_)).getOrElse(Messages("employmenthistory.nopaydata"))</td>
-                </tr>
-
-                <tr class="govuk-table__row">
-                    <th class="govuk-table__header">@messages("lbl.income.tax")</th>
-                    <td class="govuk-table__cell govuk-table__cell--numeric">@payAndTax.taxTotalIncludingEYU.map(Currency(_)).getOrElse(Messages("employmenthistory.nopaydata"))</td>
-                </tr>
+            <dl class="govuk-summary-list govuk-!-margin-bottom-9" id="pay-and-tax-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key govuk-!-font-weight-bold">
+                        @messages("lbl.taxable.income")
+                    </dt>
+                    <dd class="govuk-summary-list__value" id="taxable-income">
+                        @payAndTax.taxablePayTotalIncludingEYU.map(Currency(_)).getOrElse(Messages("employmenthistory.nopaydata"))
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key govuk-!-font-weight-bold">
+                        @messages("lbl.income.tax")
+                    </dt>
+                    <dd class="govuk-summary-list__value" id="income-tax-paid">
+                        @payAndTax.taxTotalIncludingEYU.map(Currency(_)).getOrElse(Messages("employmenthistory.nopaydata"))
+                    </dd>
+                </div>
                 @for(studentLoan <- payAndTax.studentLoanIncludingEYU) {
-                    <tr class="govuk-table__row">
-                        <th class="govuk-table__header">@messages("employmenthistory.student.loans")</th>
-                        <td class="govuk-table__cell  govuk-table__cell--numeric">@Currency(studentLoan)</td>
-                    </tr>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key govuk-!-font-weight-bold">
+                            @messages("employmenthistory.student.loans")
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            @Currency(studentLoan)
+                        </dd>
+                    </div>
                 }
-            </table>
+            </dl>
         }
         case None => {
             <p id="no-payments" class="govuk-body">@messages("employmenthistory.no.pay.and.tax", employment.employerName, employment.startDateFormatted.getOrElse(""))</p>

--- a/test/views/taxhistory/EmploymentDetailViewSpec.scala
+++ b/test/views/taxhistory/EmploymentDetailViewSpec.scala
@@ -208,15 +208,17 @@ class EmploymentDetailViewSpec extends GuiceAppSpec with BaseViewSpec with Const
       val endDate: Element       =
         document(view).getElementById("employment-data-desktop").child(1).child(7)
 
-      val taxablePay: Element = document(view).getElementById("pay-and-tax-table").child(0).child(0)
-      val incomeTax: Element  = document(view).getElementById("pay-and-tax-table").child(0).child(1)
+      val taxableIncome: Element =
+        document(view).getElementById("taxable-income")
+      val incomeTaxPaid: Element =
+        document(view).getElementById("income-tax-paid")
 
       payeReference.text should include(employment.payeReference)
       payrollId.text     should include(employment.worksNumber)
       startDate.text     should include(employment.startDateFormatted.get)
       endDate.text       should include(employment.endDateFormatted.get)
-      taxablePay.text    should include("£4,906.80")
-      incomeTax.text     should include("£1,007.34")
+      taxableIncome.text should include("£4,906.80")
+      incomeTaxPaid.text should include("£1,007.34")
     }
 
     "not have payroll ID and status for a pension" in new ViewFixture {
@@ -230,14 +232,14 @@ class EmploymentDetailViewSpec extends GuiceAppSpec with BaseViewSpec with Const
         createEmploymentViewDetail(isPension = false, employment.employerName)
       )(request, messages, appConfig)
 
-      val startDate: Element  =
+      val startDate: Element     =
         document(view).getElementById("employment-data-desktop").child(1).child(3)
-      val endDate: Element    =
+      val endDate: Element       =
         document(view).getElementById("employment-data-desktop").child(1).child(5)
-      val taxablePay: Element =
-        document(view).getElementById("pay-and-tax-table").child(0).child(0)
-      val incomeTax: Element  =
-        document(view).getElementById("pay-and-tax-table").child(0).child(1)
+      val taxableIncome: Element =
+        document(view).getElementById("taxable-income")
+      val incomeTaxPaid: Element =
+        document(view).getElementById("income-tax-paid")
 
       document(view).getElementsContainingText(employment.worksNumber).hasText shouldBe false
       document(view)
@@ -247,8 +249,8 @@ class EmploymentDetailViewSpec extends GuiceAppSpec with BaseViewSpec with Const
         .hasText                                                               shouldBe false
       startDate.text                                                             should include(employment.startDate.get.format(format))
       endDate.text                                                               should include(employment.endDate.get.format(format))
-      taxablePay.text                                                            should include("£4,906.80")
-      incomeTax.text                                                             should include("£1,007.34")
+      taxableIncome.text                                                         should include("£4,906.80")
+      incomeTaxPaid.text                                                         should include("£1,007.34")
     }
 
     "have correct Earlier Year Update details" in new ViewFixture {
@@ -346,9 +348,10 @@ class EmploymentDetailViewSpec extends GuiceAppSpec with BaseViewSpec with Const
           createEmploymentViewDetail(isPension = false, employment.employerName)
         )(request, messages, appConfig)
 
-        val taxablePay: Element = document(view).getElementById("pay-and-tax-table").child(0).child(1)
+        val taxableIncome: Element =
+          document(view).getElementById("taxable-income")
 
-        taxablePay.text should include(Messages("No data available"))
+        taxableIncome.text should include(Messages("No data available"))
       }
     }
 


### PR DESCRIPTION
### DDCE-3454: Change table to description list in employment single-records

Replaced table with `<dl>` as advised by https://github.com/hmrc/accessibility-audits-external/issues/3750
Added custom CSS to make appearance closer to previous table.
Run against this AT [PR](https://github.com/hmrc/tax-history-acceptance-tests/pull/172)