### PR TITLE
DDCE-3447 Fix up horizontal padding in tax-history views

### DIFF
--- a/app/controllers/EmploymentSummaryController.scala
+++ b/app/controllers/EmploymentSummaryController.scala
@@ -97,15 +97,15 @@ class EmploymentSummaryController @Inject() (
             } yield (allowanceResponse, taxAccountResponse, statePensionResponse, incomeTotals)).map { dataResponse =>
               Ok(
                 employmentSummary(
-                  ninoField.nino,
-                  taxYear,
-                  employments,
-                  getAllowancesFromResponse(allowancesResponse = dataResponse._1),
-                  person,
-                  getTaxAccountFromResponse(taxAccountResponse = dataResponse._2),
-                  getStatePensionsFromResponse(statePensionResponse = dataResponse._3),
+                  nino = ninoField.nino,
+                  taxYear = taxYear,
+                  employments = employments,
+                  allowances = getAllowancesFromResponse(allowancesResponse = dataResponse._1),
+                  person = person,
+                  taxAccount = getTaxAccountFromResponse(taxAccountResponse = dataResponse._2),
+                  statePension = getStatePensionsFromResponse(statePensionResponse = dataResponse._3),
                   incomeTotals = dataResponse._4,
-                  dateUtils.nowDateFormatted
+                  formattedNowDate = dateUtils.nowDateFormatted
                 )
               )
             }

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -76,11 +76,8 @@
 }
 
 @content = {
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full govuk-width-container">
-            @mainContent
-        </div>
-    </div>
+
+    @mainContent
 
     <div class="govuk-!-font-size-19">
         @hmrcReportTechnicalIssueHelper()
@@ -165,6 +162,6 @@
     headerBlock = header,
     beforeContentBlock = Some(beforeContentBlock),
     footerBlock = hmrcStandardFooter(),
-    mainClasses = Some("govuk-main-wrapper--auto-spacing"),
+    mainClasses = Some("govuk-width-container"),
     bodyEndBlock = Some(hmrcScripts())
 )(content)

--- a/app/views/taxhistory/employment_detail.scala.html
+++ b/app/views/taxhistory/employment_detail.scala.html
@@ -38,35 +38,33 @@
 @govukWrapper(PageTitle(employmentViewDetail.title), backLink = Some(controllers.routes.EmploymentSummaryController.getTaxHistory(taxYear).url)) {
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <header class="hmrc-page-heading no-top-margin">
-            <h1 class="govuk-heading-xl no-bottom-margin">
-                @employmentViewDetail.heading
-            </h1>
-            <p id="pre-header" class="hmrc-caption govuk-caption-l govuk-!-padding-bottom-1">
-                <span class="govuk-visually-hidden">This section relates to </span>
-                @clientNameOrNino
-            </p>
-            <span class="govuk-heading-m" id="taxYearRange">@messages("employmenthistory.taxyear", taxYear.toString, (taxYear + 1).toString)</span>
-        </header>
-        @payments()
+<div class="govuk-grid-column-two-thirds">
+    <header class="hmrc-page-heading no-top-margin">
+        <h1 class="govuk-heading-xl no-bottom-margin">
+            @employmentViewDetail.heading
+        </h1>
+        <p id="pre-header" class="hmrc-caption govuk-caption-l govuk-!-padding-bottom-1">
+            <span class="govuk-visually-hidden">This section relates to </span>
+            @clientNameOrNino
+        </p>
+        <span class="govuk-heading-m" id="taxYearRange">@messages("employmenthistory.taxyear", taxYear.toString, (taxYear + 1).toString)</span>
+    </header>
 
-        @if(!employment.isJobseekersAllowance) {
-            @earlierYearUpdates()
+    @payments()
 
-            @companyBenefitsInfo()
-
-            @taxCodeBreakdown()
-        }
-
-    </div>
-    <div class="govuk-grid-column-one-third">
-        <section class="section subsection">
-            <section class="employment-summary deskContent govuk-section-break" id="details-bar-desktop">
-                <div class="no-top-margin" id="employment-data-desktop">@employmentDetails()</div>
-            </section>
+    @if(!employment.isJobseekersAllowance) {
+        @earlierYearUpdates()
+        @companyBenefitsInfo()
+        @taxCodeBreakdown()
+    }
+</div>
+<div class="govuk-grid-column-one-third">
+    <section class="section subsection">
+        <section class="employment-summary deskContent govuk-section-break" id="details-bar-desktop">
+            <div class="no-top-margin" id="employment-data-desktop">@employmentDetails()</div>
         </section>
-    </div>
+    </section>
+</div>
 </div>
 }
 

--- a/app/views/taxhistory/employment_summary.scala.html
+++ b/app/views/taxhistory/employment_summary.scala.html
@@ -50,110 +50,109 @@
 
 @govukWrapper(PageTitle(messages("employmenthistory.title")), backLink =  Some(controllers.routes.SelectTaxYearController.getSelectTaxYearPage().url)) {
 
-<header class="hmrc-page-heading no-top-margin">
-    <h1 class="govuk-heading-xl no-bottom-margin" id="header">@messages("employmenthistory.header")</h1>
-    <p id="pre-header" class="hmrc-caption govuk-caption-l govuk-!-padding-bottom-1">
-        <span class="govuk-visually-hidden">This section relates to </span>
-        @getName
-    </p>
-    <span class="govuk-heading-m" id="taxYearRange">@messages("employmenthistory.taxyear", taxYear.toString, (taxYear+1).toString) </span>
-</header>
+    <header class="hmrc-page-heading no-top-margin">
+        <h1 class="govuk-heading-xl no-bottom-margin" id="header">@messages("employmenthistory.header")</h1>
+        <p id="pre-header" class="hmrc-caption govuk-caption-l govuk-!-padding-bottom-1">
+            <span class="govuk-visually-hidden">This section relates to</span>
+            @getName
+        </p>
+        <span class="govuk-heading-m" id="taxYearRange">@messages("employmenthistory.taxyear", taxYear.toString, (taxYear+1).toString)</span>
+    </header>
 
-<div class="govuk-inset-text govuk-!-margin-bottom-9 no-top-margin">
-    @p(Html(messages("employmenthistory.caveat.p.text")), id = Some("disclaimer"))
-</div>
-
-<div class="govuk-tabs" data-module="govuk-tabs">
-
-    <ul class="govuk-tabs__list" role="tablist">
-
-        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-            @link(
-                link = "#income-records",
-                messageKey = messages("employmenthistory.employment.summary.tab.1"),
-                classes = "govuk-tabs__tab",
-                id = Some("tab1")
-            )
-        </li>
-
-        @if(!isCurrentYear) {
-        <li class="govuk-tabs__list-item">
-            @link(
-                link = "#allowances",
-                messageKey = messages("employmenthistory.employment.summary.tab.2"),
-                classes = "govuk-tabs__tab",
-                id = Some("tab2")
-            )
-        </li>
-        }
-
-        @if(taxYear == TaxYear.current.previous.currentYear) {
-        <li class="govuk-tabs__list-item">
-            @link(
-                link = "#underpaid-tax-and-debts",
-                messageKey = messages("employmenthistory.employment.summary.tab.3"),
-                classes = "govuk-tabs__tab",
-                id = Some("tab3")
-            )
-        </li>
-        }
-    </ul>
-
-    <div class="govuk-tabs__panel" id="income-records">
-        @if(employments.exists(!_.isOccupationalPension)) {
-            @employmentTable
-        } else {
-            <h2 class="govuk-heading-l no-top-margin">@messages("employmenthistory.employment.records")</h2>
-            <p class="govuk-caption-m" id="no-benefits">@messages("employmenthistory.no.employments")</p>
-        }
-
-        <h2 class="govuk-heading-l">@messages("employmenthistory.table.header.pensions")</h2>
-        @if(employments.exists(_.isOccupationalPension)) {
-            @pensionTable
-        } else {
-            <p id="no-pensions" class="govuk-caption-m">@messages("employmenthistory.no.pensions")</p>
-        }
-
-        @statePension.map { sp =>
-            <h3 id = "StatePensions" class="govuk-heading-m">@messages("employmenthistory.state.pensions")</h3>
-            <div class = "govuk-grid-row">
-                <div class = "govuk-grid-column-two-thirds">
-                    @if(TaxYear.current.currentYear == taxYear) {
-                        @p{@messages("employmenthistory.state.pensions.text.weekly.p1", s"${Currency(sp.weeklyAmount, 2)}", sp.startDateFormatted.getOrElse(""))}
-                        @p{@messages("employmenthistory.state.pensions.text.weekly.p2", formattedNowDate, s"${Currency.fromOptionBD(sp.getAmountReceivedTillDate(taxYear))}")}
-                    } else {
-                        @p{@messages("employmenthistory.state.pensions.text.yearly", s"${Currency(sp.grossAmount, 2)}")}
-                    }
-                </div>
-                <div class ="govuk-grid-column-one-third"></div>
-            </div>
-        }
-
+    <div class="govuk-inset-text govuk-!-margin-bottom-9 no-top-margin">
+        @p(Html(messages("employmenthistory.caveat.p.text")), id = Some("disclaimer"))
     </div>
 
-    @if(!isCurrentYear) {
-        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="allowances">
-            <h2 id = "AllowancesHeader" class="govuk-heading-l">@messages("employmenthistory.allowance.heading")</h2>
+    <div class="govuk-tabs" data-module="govuk-tabs">
 
-            @if(allowances.nonEmpty) {
-                @allowanceTable
-            } else {
-                <p id="no-allowances" class="govuk-caption-m">@messages("employmenthistory.allowance.no-allowances")</p>
+        <ul class="govuk-tabs__list" role="tablist">
+
+            <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                @link(
+                    link = "#income-records",
+                    messageKey = messages("employmenthistory.employment.summary.tab.1"),
+                    classes = "govuk-tabs__tab",
+                    id = Some("tab1")
+                )
+            </li>
+
+            @if(!isCurrentYear) {
+                <li class="govuk-tabs__list-item">
+                    @link(
+                        link = "#allowances",
+                        messageKey = messages("employmenthistory.employment.summary.tab.2"),
+                        classes = "govuk-tabs__tab",
+                        id = Some("tab2")
+                    )
+                </li>
             }
+
+            @if(taxYear == TaxYear.current.previous.currentYear) {
+                <li class="govuk-tabs__list-item">
+                    @link(
+                        link = "#underpaid-tax-and-debts",
+                        messageKey = messages("employmenthistory.employment.summary.tab.3"),
+                        classes = "govuk-tabs__tab",
+                        id = Some("tab3")
+                    )
+                </li>
+            }
+        </ul>
+
+        <div class="govuk-tabs__panel " id="income-records">
+            @if(employments.exists(!_.isOccupationalPension)) {
+
+                    @employmentTable
+            } else {
+                <h2 class="govuk-heading-l no-top-margin">@messages("employmenthistory.employment.records")</h2>
+                <p class="govuk-caption-m" id="no-benefits">@messages("employmenthistory.no.employments")</p>
+            }
+
+            <h2  class="govuk-heading-l">@messages("employmenthistory.table.header.pensions")</h2>
+                @if(employments.exists(_.isOccupationalPension)) {
+
+                            @pensionTable
+                } else {
+                    <p id="no-pensions" class="govuk-caption-m">@messages("employmenthistory.no.pensions")</p>
+                }
+
+                @statePension.map { sp =>
+                    <h3 id = "StatePensions" class="govuk-heading-m">@messages("employmenthistory.state.pensions")</h3>
+                    <div class = "govuk-grid-row">
+                        <div class = "govuk-grid-column-two-thirds">
+                            @if(TaxYear.current.currentYear == taxYear) {
+                                @p{@messages("employmenthistory.state.pensions.text.weekly.p1", s"${Currency(sp.weeklyAmount, 2)}", sp.startDateFormatted.getOrElse(""))}
+                                @p{@messages("employmenthistory.state.pensions.text.weekly.p2", formattedNowDate, s"${Currency.fromOptionBD(sp.getAmountReceivedTillDate(taxYear))}")}
+                            } else {
+                                @p{@messages("employmenthistory.state.pensions.text.yearly", s"${Currency(sp.grossAmount, 2)}")}
+                            }
+                        </div>
+                        <div class ="govuk-grid-column-one-third"></div>
+                    </div>
+                }
         </div>
-    }
-    @if(!isCurrentYear) {
-        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="underpaid-tax-and-debts">
-            @if(taxAccount.nonEmpty) {
+        @if(!isCurrentYear) {
+            <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="allowances">
+                <h2 id = "AllowancesHeader" class="govuk-heading-l">@messages("employmenthistory.allowance.heading")</h2>
+                @if(allowances.nonEmpty) {
+                    @allowanceTable
+                } else {
+                    <p id="no-allowances" class="govuk-caption-m">@messages("employmenthistory.allowance.no-allowances")</p>
+                }
+            </div>
+        }
+        @if(!isCurrentYear) {
+            <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="underpaid-tax-and-debts">
+                @if(taxAccount.nonEmpty) {
                 @taxAccountTable
             } else {
-            <h2 class="govuk-heading-l">@messages("employmenthistory.tax-account.header")</h2>
-            <p id="no-tax-account" class="govuk-body">@messages("employmenthistory.tax-account.empty.text")</p>
-            }
-        </div>
-    }
+            <h2  class="govuk-heading-l">@messages("employmenthistory.tax-account.header")</h2>
 
-</div>
+                 <p id="no-tax-account" class="govuk-body">@messages("employmenthistory.tax-account.empty.text")</p>
+                }
+            </div>
+        }
+    </div>
 }
 
 @employmentTable ={

--- a/test/views/GovUkWrapperViewSpec.scala
+++ b/test/views/GovUkWrapperViewSpec.scala
@@ -60,7 +60,7 @@ class GovUkWrapperViewSpec extends GuiceAppSpec with BaseViewSpec {
 
   private def document(view: HtmlFormat.Appendable): Document = Jsoup.parse(view.toString())
 
-  private def renderViewTest(method: String, view: HtmlFormat.Appendable): Unit = {
+  private def renderViewTest(method: String, view: HtmlFormat.Appendable): Unit =
     s"$method" should {
       "display the correct title" in {
         document(view).title shouldBe expectedPageTitle("page title")
@@ -70,15 +70,13 @@ class GovUkWrapperViewSpec extends GuiceAppSpec with BaseViewSpec {
         document(view).select("h1").text() shouldBe "page heading"
       }
     }
-  }
 
-  private def languageTest(scenario: String, language: String, view: HtmlFormat.Appendable): Unit = {
+  private def languageTest(scenario: String, language: String, view: HtmlFormat.Appendable): Unit =
     s"$scenario" should {
       s"render the html lang as $language" in {
         document(view).select("html").attr("lang") shouldBe language
       }
     }
-  }
 
   "GovUkWrapperView" when {
     renderViewTest(".apply", viewViaApply())

--- a/test/views/errors/NoAgentServicesAccountViewSpec.scala
+++ b/test/views/errors/NoAgentServicesAccountViewSpec.scala
@@ -50,13 +50,13 @@ class NoAgentServicesAccountViewSpec extends GuiceAppSpec with BaseViewSpec {
         }
 
         "have the correct p element content" in new ViewFixture(view) {
-          document(view).select("#main-content > div > div > div > div > p").text() shouldBe pContent
+          document(view).select("#main-content > div > div > p").text() shouldBe pContent
         }
 
         "have the correct a element content" in new ViewFixture(view) {
           document(view)
             .select(
-              "#main-content > div > div > div > div > p > a"
+              "#main-content > div > div > p> a"
             )
             .text() shouldBe "create an agent services account"
         }
@@ -64,7 +64,7 @@ class NoAgentServicesAccountViewSpec extends GuiceAppSpec with BaseViewSpec {
         "have the correct a element link" in new ViewFixture(view) {
           document(view)
             .select(
-              "#main-content > div > div > div > div > p > a"
+              "#main-content > div > div > p> a"
             )
             .attr("href") shouldBe "https://www.gov.uk/guidance/get-an-hmrc-agent-services-account"
         }

--- a/test/views/taxhistory/EmploymentDetailViewSpec.scala
+++ b/test/views/taxhistory/EmploymentDetailViewSpec.scala
@@ -79,13 +79,13 @@ class EmploymentDetailViewSpec extends GuiceAppSpec with BaseViewSpec with Const
     val incomeSourceWithDeductionsAndAllowances: Option[IncomeSource] =
       Some(IncomeSource(1, 1, None, deductions, allowances, "1100Y", None, 1, ""))
 
-    val taxCodeH2                   = "#main-content > div > div > div > div > h2"
+    val taxCodeH2                   = "#main-content > div > div > h2"
     val taxCodeAllowancesH3         = "#tax-code-allowances"
     val taxCodeDeductionsH3         = "#tax-code-deductions"
-    val taxCodeSubheading           = "#main-content > div > div > div > div > div > dl > dt"
-    val taxCodeNumber               = "#main-content > div > div > div > div > div > dl > dd"
-    val deductionsP                 = "#main-content > div > div > div > div > p"
-    val noDeductions                = "#main-content > div > div > div > div > span#no-deductions"
+    val taxCodeSubheading           = "#main-content > div > div > div > dl > dt"
+    val taxCodeNumber               = "#main-content > div > div > div > dl > dd"
+    val deductionsP                 = "#main-content > div > div > p"
+    val noDeductions                = "#main-content > div > div > span#no-deductions"
     val deductionsParagraph: String =
       "Where an amount is owed to HMRC, a deduction is calculated to adjust the tax code so " +
         "that the correct amount is repaid over the course of the year."

--- a/test/views/taxhistory/SelectTaxYearViewSpec.scala
+++ b/test/views/taxhistory/SelectTaxYearViewSpec.scala
@@ -126,7 +126,7 @@ class SelectTaxYearViewSpec extends GuiceAppSpec with BaseViewSpec {
       val view: HtmlFormat.Appendable     = inject[select_tax_year].apply(validForm, options, noSelectedTaxYear, name, nino)
 
       def radioLabel(i: Int): String =
-        s"#main-content > div > div > div > div > form > div > fieldset > div > div:nth-child($i) > label"
+        s"#main-content > div > div > form > div > fieldset > div > div:nth-child($i) > label"
 
       document(view).select(radioLabel(1)).text() mustBe "2016 to 2017"
       document(view).select(radioLabel(2)).text() mustBe "2015 to 2016"


### PR DESCRIPTION
Unit and ATs ran and should pass

Summary of changes
Padding was non-existent on the right hand side of the page during small screens despite fixing the gray employment/pension details box in employment_details. Changing the wrapper and removing unnecessary/clashing classes and their respective divs retained the padding on the the employment_details page (desired page to fix) and pre-existing pages. There is still a pre-existing issue with the employment summary page with tables not snapping back and scaling with screen size. Which is already on main but I've left it out for now as it would likely be a more complicated fix/out of scope.