### PR TITLE
DDCE-3443: Enable new tab hover styles

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
   private val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "7.7.0-play-28",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "7.9.0-play-28",
     "uk.gov.hmrc" %% "domain"                     % "8.3.0-play-28",
     "uk.gov.hmrc" %% "tax-year"                   % "3.2.0"
   )
@@ -17,7 +17,7 @@ object AppDependencies {
     "org.scalatest"       %% "scalatest"               % "3.2.16",
     "org.jsoup"            % "jsoup"                   % "1.16.1",
     "org.mockito"         %% "mockito-scala-scalatest" % "1.17.14",
-    "com.vladsch.flexmark" % "flexmark-all"            % "0.64.6"
+    "com.vladsch.flexmark" % "flexmark-all"            % "0.64.8"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID]      = compile ++ test

--- a/test/views/taxhistory/EmploymentSummaryViewSpec.scala
+++ b/test/views/taxhistory/EmploymentSummaryViewSpec.scala
@@ -105,7 +105,7 @@ class EmploymentSummaryViewSpec extends GuiceAppSpec with BaseViewSpec with Cons
 
     "have a table of employments and" should {
 
-      def viewLinkSpan(linkMessage: String, visuallyHiddenMessage: String) =
+      def viewLinkSpan(linkMessage: String, visuallyHiddenMessage: String): String =
         "<span aria-hidden=\"true\">" + linkMessage + "</span> " +
           "<span class=\"govuk-visually-hidden\">" + visuallyHiddenMessage + "</span>"
 
@@ -151,7 +151,7 @@ class EmploymentSummaryViewSpec extends GuiceAppSpec with BaseViewSpec with Cons
 
     "have a table for pensions and" should {
 
-      def viewLinkSpan(linkMessage: String, visuallyHiddenMessage: String) =
+      def viewLinkSpan(linkMessage: String, visuallyHiddenMessage: String): String =
         "<span aria-hidden=\"true\">" + linkMessage + "</span> " +
           "<span class=\"govuk-visually-hidden\">" + visuallyHiddenMessage + "</span>"
 


### PR DESCRIPTION
### DDCE-3443: Enable new tab hover styles

PlatUI has now enabled the new hover styles shown at https://design-system.service.gov.uk/components/tabs/
Updated to `play-frontend-hmrc` to `7.9.0-play-28` covers this