### PR TITLE
DDCE-4367: Add data setup to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This automatically generates sample data for this Agent.
 Set the "Credential Strength" to **Strong** and record the **ARN** number (AgentReferenceNumber) under the heading "Principal enrolments" assigned to this user.
 ```example: QARN8691038```
 
-Press Update and continue.
+Press Update to continue.
 
 ### Create Client user
 
@@ -64,7 +64,7 @@ This automatically generates sample data for this Client.
 Set the "Credential Strength" to **Strong** and record the **NINO** (or edit to a custom NINO to include more test data [see here](#checking-the-added-client-data)).
 ```example: AM242413B```
 
-Press Update and continue. 
+Press Update to continue. 
 
 
 ### Create the relationship between Agent and Client

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 Source code for the front end microservice for the Income Record Viewer service
 
-### License
+## Running the application
 
-This code is open source software licensed under
-the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html")
+Before running this frontend, start all dependant services in Service Manager 2:
 
-### Running the application
+```bash
+sm2 --start TAX_HISTORY_ALL
+sm2 --stop TAX_HISTORY_FRONTEND
+```
 
 In order to run the microservice, you must have SBT installed. You should then be able to start the application using:
 
@@ -27,5 +29,79 @@ or to run tests+coverage+scalafmt+scalastyle run:
 ./run_all_tests.sh
 ```
 
-Landing page URL for the service is: http://localhost:9996/tax-history/select-client
+The landing page URL for the service is: http://localhost:9996/tax-history/select-client [[staging](https://www.staging.tax.service.gov.uk/tax-history/select-client)]
 
+You will need an Agent account to sign-in [see Create Agent user](#create-agent-user).
+
+## Manually adding test data
+
+This frontend allows an Agent to view Income record details about a client therefore a relationship between the two needs to be formed.
+
+### Create Agent user
+
+To create an agent head to http://localhost:9553/agents-external-stubs/gg/sign-in [[staging](https://www.staging.tax.service.gov.uk/agents-external-stubs/gg/sign-in)] and complete the sign-in form filling any UserID and Planet.
+
+This redirects to the user creation page. Set the "Affinity group" to **Agent** which populates "Principal enrolment" with the value **HMRC-AS-AGENT**.
+Press Create.
+
+This automatically generates sample data for this Agent.
+Set the "Credential Strength" to **Strong** and record the **ARN** number (AgentReferenceNumber) under the heading "Principal enrolments" assigned to this user.
+```example: QARN8691038```
+
+Press Update and continue.
+
+### Create Client user
+
+If signed in with the Agent user, create the client user using the form in the panel or using
+[http://localhost:9553/agents-external-stubs/user/create?userId={InsertClientID}](http://localhost:9553/agents-external-stubs/user/create?userId=SampleClient) [[staging](https://www.staging.tax.service.gov.uk/agents-external-stubs/user/create?userId=SampleClient)].
+
+Being signed in as the Agent from the creation step ensures this second user is stored within the same _Planet_.
+
+Set the "Affinity group" to **Individual** which populates "Principal enrolment" with the value **HMRC-MTD-IT**.
+Press Create.
+
+This automatically generates sample data for this Client.
+Set the "Credential Strength" to **Strong** and record the **NINO** (or edit to a custom NINO to include more test data [see here](#checking-the-added-client-data)).
+```example: AM242413B```
+
+Press Update and continue. 
+
+
+### Create the relationship between Agent and Client
+
+To create a relationship head to http://localhost:9448/invitations/test-only/relationships/create [[staging](https://www.staging.tax.service.gov.uk/invitations/test-only/relationships/create)].
+
+Fill in the fields
+- ARN should match the **ARN** recorded from the **Agent** in the creation step.
+- Service should be set to **PERSONAL-INCOME-RECORD**
+- Client ID should match the **NINO** recorded from the **Client** in the creation step.
+
+Press Create.
+
+_Note - the relationship url in staging can be inconsistent. If wanting to test in staging, run the [performance tests](https://github.com/hmrc/tax-history-performance-tests) and test with NINO `AM242413B` which contains all varieties of tax data for different years._
+
+### Checking the added client data
+
+Go to http://localhost:9996/tax-history/select-client [[staging](https://www.staging.tax.service.gov.uk/tax-history/select-client)]. Sign in as the Agent created before.
+
+When entering the NINO the name of the client created should be found.
+
+Currently, a new client will have no data assigned to them relating to tax years.
+This data is retrieved using [tax-history](https://github.com/hmrc/tax-history) and [citizen-details](https://github.com/hmrc/citizen-details) in production.
+
+Using the NINO's available in [stubbed data](https://github.com/hmrc/tax-history-stubs/tree/main/conf/resources/data)
+at client creation ensures there are details for a clients specific tax years.
+Otherwise, run the stub repository locally and create custom data in the same format for the generated client.
+
+### Troubleshooting
+
+If the expected user does not sign in correctly. Sign in with a new user on the same _Planet_.
+
+Go to "Test Users" http://localhost:9553/agents-external-stubs/users [[staging](https://www.staging.tax.service.gov.uk/agents-external-stubs/users)] and remove the problematic user and reform the relationship.
+
+If there are still issues, press _**End this planet and destroy the data**_ and start over.
+
+## License
+
+This code is open source software licensed under
+the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html")

--- a/app/model/api/Allowance.scala
+++ b/app/model/api/Allowance.scala
@@ -16,12 +16,12 @@
 
 package model.api
 
-import java.util.UUID
+import play.api.libs.json.{Json, OFormat}
 
-import play.api.libs.json.Json
+import java.util.UUID
 
 case class Allowance(allowanceId: UUID = UUID.randomUUID(), iabdType: String, amount: BigDecimal)
 
 object Allowance {
-  implicit val formats = Json.format[Allowance]
+  implicit val formats: OFormat[Allowance] = Json.format[Allowance]
 }

--- a/app/model/api/CompanyBenefit.scala
+++ b/app/model/api/CompanyBenefit.scala
@@ -16,9 +16,9 @@
 
 package model.api
 
-import java.util.UUID
+import play.api.libs.json.{Json, OFormat}
 
-import play.api.libs.json.Json
+import java.util.UUID
 
 case class CompanyBenefit(
   companyBenefitId: UUID = UUID.randomUUID(),
@@ -29,5 +29,5 @@ case class CompanyBenefit(
 )
 
 object CompanyBenefit {
-  implicit val formats = Json.format[CompanyBenefit]
+  implicit val formats: OFormat[CompanyBenefit] = Json.format[CompanyBenefit]
 }

--- a/app/model/api/EarlierYearUpdate.scala
+++ b/app/model/api/EarlierYearUpdate.scala
@@ -16,11 +16,11 @@
 
 package model.api
 
-import java.util.UUID
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import utils.LocalDateFormat
 
 import java.time.LocalDate
+import java.util.UUID
 
 case class EarlierYearUpdate(
   earlierYearUpdateId: UUID = UUID.randomUUID(),
@@ -32,5 +32,5 @@ case class EarlierYearUpdate(
 )
 
 object EarlierYearUpdate extends LocalDateFormat {
-  implicit val formats = Json.format[EarlierYearUpdate]
+  implicit val formats: OFormat[EarlierYearUpdate] = Json.format[EarlierYearUpdate]
 }

--- a/app/model/api/EmploymentStatus.scala
+++ b/app/model/api/EmploymentStatus.scala
@@ -27,12 +27,13 @@ object EmploymentStatus {
   case object Ceased extends EmploymentStatus
   case object Unknown extends EmploymentStatus
 
-  private val LIVE              = 1
-  private val POTENTIALLYCEASED = 2
-  private val CEASED            = 3
-  private val UNKNOWN           = 99 // Code 99, Unknown, is internal to tax-history, and is not an wider HMRC employment status
+  private val LIVE: Int              = 1
+  private val POTENTIALLYCEASED: Int = 2
+  private val CEASED: Int            = 3
+  private val UNKNOWN: Int           =
+    99 // Code 99, Unknown, is internal to tax-history, and is not an wider HMRC employment status
 
-  implicit val jsonReads =
+  implicit val jsonReads: Reads[EmploymentStatus] =
     (__ \ "employmentStatus").read[Int].flatMap[EmploymentStatus] {
       case LIVE              => Reads(_ => JsSuccess(Live))
       case POTENTIALLYCEASED => Reads(_ => JsSuccess(PotentiallyCeased))
@@ -41,7 +42,7 @@ object EmploymentStatus {
       case _                 => Reads(_ => JsError(JsPath \ "employmentStatus", JsonValidationError("Invalid EmploymentStatus")))
     }
 
-  implicit val jsonWrites = Writes[EmploymentStatus] {
+  implicit val jsonWrites: Writes[EmploymentStatus] = Writes[EmploymentStatus] {
     case Live              => Json.obj("employmentStatus" -> LIVE)
     case PotentiallyCeased => Json.obj("employmentStatus" -> POTENTIALLYCEASED)
     case Ceased            => Json.obj("employmentStatus" -> CEASED)

--- a/app/model/api/IndividualTaxYear.scala
+++ b/app/model/api/IndividualTaxYear.scala
@@ -16,10 +16,10 @@
 
 package model.api
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class IndividualTaxYear(year: Int, allowancesURI: String, employmentsURI: String, taxAccountURI: String)
 
 object IndividualTaxYear {
-  implicit val formats = Json.format[IndividualTaxYear]
+  implicit val formats: OFormat[IndividualTaxYear] = Json.format[IndividualTaxYear]
 }

--- a/app/model/api/NpsTaxAccount.scala
+++ b/app/model/api/NpsTaxAccount.scala
@@ -16,18 +16,18 @@
 
 package model.api
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class TaDeduction(`type`: Int, npsDescription: String, amount: BigDecimal, sourceAmount: Option[BigDecimal])
 
 object TaDeduction {
-  implicit val formats = Json.format[TaDeduction]
+  implicit val formats: OFormat[TaDeduction] = Json.format[TaDeduction]
 }
 
 case class TaAllowance(`type`: Int, npsDescription: String, amount: BigDecimal, sourceAmount: Option[BigDecimal])
 
 object TaAllowance {
-  implicit val formats = Json.format[TaAllowance]
+  implicit val formats: OFormat[TaAllowance] = Json.format[TaAllowance]
 }
 
 case class IncomeSource(
@@ -43,5 +43,5 @@ case class IncomeSource(
 )
 
 object IncomeSource {
-  implicit val formats = Json.format[IncomeSource]
+  implicit val formats: OFormat[IncomeSource] = Json.format[IncomeSource]
 }

--- a/app/model/api/PayAndTax.scala
+++ b/app/model/api/PayAndTax.scala
@@ -16,7 +16,7 @@
 
 package model.api
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import utils.LocalDateFormat
 
 import java.time.LocalDate
@@ -41,5 +41,5 @@ case class PayAndTax(
 }
 
 object PayAndTax extends LocalDateFormat {
-  implicit val formats = Json.format[PayAndTax]
+  implicit val formats: OFormat[PayAndTax] = Json.format[PayAndTax]
 }

--- a/app/model/api/TaxAccount.scala
+++ b/app/model/api/TaxAccount.scala
@@ -16,9 +16,9 @@
 
 package model.api
 
-import java.util.UUID
+import play.api.libs.json.{Json, OFormat}
 
-import play.api.libs.json.Json
+import java.util.UUID
 
 case class TaxAccount(
   taxAccountId: UUID = UUID.randomUUID(),
@@ -28,5 +28,5 @@ case class TaxAccount(
 )
 
 object TaxAccount {
-  implicit val formats = Json.format[TaxAccount]
+  implicit val formats: OFormat[TaxAccount] = Json.format[TaxAccount]
 }

--- a/app/models/taxhistory/EarlierYearUpdate.scala
+++ b/app/models/taxhistory/EarlierYearUpdate.scala
@@ -16,7 +16,7 @@
 
 package models.taxhistory
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import utils.LocalDateFormat
 
 import java.time.LocalDate
@@ -28,5 +28,5 @@ case class EarlierYearUpdate(
 )
 
 object EarlierYearUpdate extends LocalDateFormat {
-  implicit val format = Json.format[EarlierYearUpdate]
+  implicit val format: OFormat[EarlierYearUpdate] = Json.format[EarlierYearUpdate]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -5,12 +5,11 @@ lazy val microservice = Project(appName, file("."))
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
     majorVersion := 3,
-    scalaVersion := "2.13.10",
+    scalaVersion := "2.13.11",
     libraryDependencies ++= AppDependencies(),
     // To resolve a bug with version 2.x.x of the scoverage plugin - https://github.com/sbt/sbt/issues/6997
     libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
-    PlayKeys.playDefaultPort := 9996,
-    retrieveManaged := true
+    PlayKeys.playDefaultPort := 9996
   )
   // To resolve dependency clash between flexmark v0.64.4+ and play-language to run accessibility tests, remove when versions align
   .settings(dependencyOverrides += "com.ibm.icu" % "icu4j" % "69.1")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,6 +45,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 http-verbs.retries.ssl-engine-closed-already.enabled = true
 
 microservice {
+
   services {
     auth {
       host = localhost
@@ -87,9 +88,7 @@ external-url {
   }
 }
 
-metrics {
-  enabled = true
-}
+metrics.enabled = true
 
 contact-frontend {
   host = "http://localhost:9250"

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -242,22 +242,6 @@ employmenthistory.no.agent.services.account.title=Nid oes cyfrif gwasanaethau as
 employmenthistory.no.agent.services.account.p=Os ydych wedi’ch awdurdodi i weithredu ar ran eich busnes asiant, gallwch
 employmenthistory.no.agent.services.account.link.text=creu cyfrif gwasanaethau asiant
 
-# General Messages
-# Error messages for digital services
-global.error.400.title=Cais gwallus – 400
-global.error.400.heading=Cais gwallus
-global.error.400.message=Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
-global.error.403.title=Gwaharddwyd – 403
-global.error.403.heading=Mae’n ddrwg gennym – nid ydych wedi’ch awdurdodi i fynd yn eich blaen.
-global.error.passcode.title=Gwaharddwyd – 403
-global.error.passcode.heading=Mae’n ddrwg gennym – nid ydych wedi’ch awdurdodi i fynd yn eich blaen.
-global.error.404.title=Heb ddod o hyd i’r dudalen – 404
-global.error.404.heading=Ni ellir dod o hyd i’r dudalen hon
-global.error.404.message=Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
-global.error.500.title=Mae’n ddrwg gennym. Mae anawsterau technegol wedi codi – 500
-global.error.500.heading=Mae’n ddrwg gennym. Mae anawsterau technegol wedi codi
-global.error.500.message=Rhowch gynnig arall arni mewn ychydig o funudau.
-
 #********************************************************************
 # timeout text
 #********************************************************************

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -242,22 +242,6 @@ employmenthistory.no.agent.services.account.title=Your agent business does not h
 employmenthistory.no.agent.services.account.p=If you are authorised to act on behalf of your agent business, you can
 employmenthistory.no.agent.services.account.link.text=create an agent services account
 
-# General Messages
-# Error messages for digital services
-global.error.400.title=Bad request - 400
-global.error.400.heading=Bad request
-global.error.400.message=Please check that you have entered the correct web address.
-global.error.403.title=Forbidden - 403
-global.error.403.heading=Sorry, you haven''t been authorised to proceed.
-global.error.passcode.title=Forbidden - 403
-global.error.passcode.heading=Sorry, you haven''t been authorised to proceed.
-global.error.404.title=Page not found - 404
-global.error.404.heading=This page can''t be found
-global.error.404.message=Please check that you have entered the correct web address.
-global.error.500.title=Sorry, we are experiencing technical difficulties - 500
-global.error.500.heading=Sorry, we''re experiencing technical difficulties
-global.error.500.message=Please try again in a few minutes.
-
 #********************************************************************
 # timeout text
 #********************************************************************

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "7.21.0"
+  private val bootstrapPlayVersion: String = "7.21.0"
 
   private val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build"           % "3.9.0")
-addSbtPlugin("org.scoverage"      %% "sbt-scoverage"            % "2.0.7")
+addSbtPlugin("org.scoverage"      %% "sbt-scoverage"            % "2.0.8")
 addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle"           % "1.5.1")
 addSbtPlugin("uk.gov.hmrc"         % "sbt-distributables"       % "2.2.0")
 addSbtPlugin("com.typesafe.play"   % "sbt-plugin"               % "2.8.20")

--- a/test/utils/MessagesSpec.scala
+++ b/test/utils/MessagesSpec.scala
@@ -106,11 +106,11 @@ class MessagesSpec extends GuiceAppSpec {
 
   private def isInteger(s: String): Boolean = s forall Character.isDigit
 
-  private def toArgArray(msg: String) = msg.split("\\{|\\}").map(_.trim()).filter(isInteger)
+  private def toArgArray(msg: String): Array[String] = msg.split("\\{|\\}").map(_.trim()).filter(isInteger)
 
-  private def countArgs(msg: String) = toArgArray(msg).length
+  private def countArgs(msg: String): Int = toArgArray(msg).length
 
-  private def listArgs(msg: String) = toArgArray(msg).mkString
+  private def listArgs(msg: String): String = toArgArray(msg).mkString
 
   private def assertNonEmptyValuesForDefaultMessages(): Unit =
     assertNonEmptyNonTemporaryValues("Default", englishMessageKeys)
@@ -139,10 +139,10 @@ class MessagesSpec extends GuiceAppSpec {
       }
   }
 
-  private def listMissingMessageKeys(header: String, missingKeys: Set[String]) =
+  private def listMissingMessageKeys(header: String, missingKeys: Set[String]): String =
     missingKeys.toList.sorted.mkString(header + displayLine, "\n", displayLine)
 
-  private lazy val displayLine = "\n" + ("@" * 42) + "\n"
+  private lazy val displayLine: String = "\n" + ("@" * 42) + "\n"
 
   private lazy val englishMessageKeys: Map[String, String] = getExpectedMessages("en")
 
@@ -151,7 +151,7 @@ class MessagesSpec extends GuiceAppSpec {
 
   private lazy val welshMessagesKeys: Map[String, String] = getExpectedMessages("cy") -- defaultMessageKeys
 
-  private def getExpectedMessages(languageCode: String) =
+  private def getExpectedMessages(languageCode: String): Map[String, String] =
     messagesApi.messages.getOrElse(languageCode, throw new Exception(s"Missing messages for $languageCode"))
 
   private def mismatchingKeys(defaultKeySet: Set[String], welshKeySet: Set[String]) = {


### PR DESCRIPTION
### DDCE-4367: Add data setup to Readme

- Include instructions for setting up relationships and data for viewing content.
- Upgrade to Scala 2.13.11 and other dependencies.